### PR TITLE
Moving from rpcuser/rpcpassword to cookie_file authentification/rpcauth

### DIFF
--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -106,8 +106,19 @@ Instead of creating a real directory, we create a link that points to a director
 
 ### Configuration
 
+First we neet to generate a password for rpcpassword:
+
+```wget https://raw.githubusercontent.com/bitcoin/bitcoin/master/share/rpcauth/rpcauth.py
+   $ python ./rpcuser.py raspibolt
+     String to be appended to bitcoin.conf:
+     rpcauth=raspibolt:[hashed password]
+     Your password:
+     [rpcpassword]
+
+Keep note of the rpcpassword, needed for block explorer
+
 Now, the configuration file for bitcoind needs to be created.
-Still as user "bitcoin", open it with Nano and paste the configuration below. Save and exit.
+Still as user "bitcoin", open it with Nano and paste the configuration below. Modify the rpcauth=[hashed password] line accordingly with the value generated above. Save and exit.
 
 ```sh
 $ nano /mnt/ext/bitcoin/bitcoin.conf
@@ -128,8 +139,7 @@ proxy=127.0.0.1:9050
 bind=127.0.0.1
 
 # Connections
-rpcuser=raspibolt
-rpcpassword=PASSWORD_[B]
+rpcauth=raspibolt:[hashed password]
 zmqpubrawblock=tcp://127.0.0.1:28332
 zmqpubrawtx=tcp://127.0.0.1:28333
 
@@ -141,12 +151,6 @@ maxuploadtarget=5000
 dbcache=2000
 blocksonly=1
 ```
-
-🚨 **Change the rpcpassword** to your secure `password [B]`.
-
-<script id="asciicast-gQJ1dSWPdcavFcZs5PRuYS4Ad" src="https://asciinema.org/a/gQJ1dSWPdcavFcZs5PRuYS4Ad.js" async></script>
-
-🔍 *more: [configuration options](https://en.bitcoin.it/wiki/Running_Bitcoin#Command-line_arguments){:target="_blank"} in Bitcoin Wiki*
 
 #### Transaction indexing (optional)
 

--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -114,7 +114,8 @@ First we neet to generate a password for rpcpassword:
      rpcauth=raspibolt:[hashed password]
      Your password:
      [rpcpassword]
-
+     ```
+     
 Keep note of the rpcpassword, needed for block explorer
 
 Now, the configuration file for bitcoind needs to be created.

--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -106,7 +106,7 @@ Instead of creating a real directory, we create a link that points to a director
 
 ### Configuration
 
-First we neet to generate a password for rpcpassword:
+First we need to generate a password for rpcpassword:
 
 ```wget https://raw.githubusercontent.com/bitcoin/bitcoin/master/share/rpcauth/rpcauth.py
    $ python ./rpcuser.py raspibolt

--- a/raspibolt_50_electrs.md
+++ b/raspibolt_50_electrs.md
@@ -126,8 +126,8 @@ The whole process takes about 30 minutes.
   # RaspiBolt: electrs configuration
   # /mnt/ext/electrs/electrs.conf
 
-  # RPC user / password
-  cookie = "raspibolt:PASSWORD_[B]"
+  # RPC cookie file
+  cookie_file = "/mnt/ext/bitcoin/.cookie
 
   # Bitcoin Core settings
   network = "bitcoin"

--- a/raspibolt_55_explorer.md
+++ b/raspibolt_55_explorer.md
@@ -115,8 +115,9 @@ We are going to install the BTC RPC Explorer in the home directory since it does
   BTCEXP_BITCOIND_HOST=127.0.0.1
   BTCEXP_BITCOIND_PORT=8332
   BTCEXP_BITCOIND_USER=raspibolt
-  BTCEXP_BITCOIND_PASS=PASSWORD_[B]
+  BTCEXP_BITCOIND_PASS=rpcpassword
   ```
+  Modify BTCEXP_BITCOIND_PASS using your rpcpassword generated when setting up bitcoind
 
 * To compensate for the limited resources of the Raspberry Pi, let's extend the timeout period.
 


### PR DESCRIPTION
Using current configuration recommendation when starting bitcoind the following message appear:
`Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcuser for rpcauth auth generation`

The following modification allows us to use rpcauth using rpcuser.py script available at [bitcoin/bitcoin](https://github.com/bitcoin/bitcoin/blob/master/share/rpcauth/rpcauth.py)
Once rpcauth is set up and the rpcpassword line replaced by rpcauth bitcoind creates a .cookie cookie authentication file at startup. (Actually when no rpcpassword is set in bitcoin.conf bitcoind creates a .cookie file when the service starts et deletes it at exit)
We use this method of authentication instead of the deprecated rpcuser/rpcpassword one to authenticate Electrs to our node.

Finally, as btcrpcexplorer does not have access permission to the cookie authentication file we use rpcuser/rpc password but this time using the password created by rpcuser.py script as recommended.

More info [here](https://bitcoin.org/en/release/v0.12.0#rpc-random-cookie-rpc-authentication) and [here](https://bitcoin.stackexchange.com/questions/46782/rpc-cookie-authentication).

EDIT:
The .cookie file is created with umask 0022 setting its permission to 600 -rw------. Making it unreadable to admin user. We could add In the service unit the ```UMask=0027``` value and ```sysperms=1``` in bitcoin.conf so the default system permission is 640. 

EDIT2:
We could give access permissions to the .cookie file for btcrpcexprorer user adding it the the bitcoin group. Thoughs?