### PR TITLE
MOTD falsely claims that the Bitcoin needs to be updated

### DIFF
--- a/resources/20-raspibolt-welcome
+++ b/resources/20-raspibolt-welcome
@@ -200,13 +200,16 @@ fi
 
 #create variable btcversion
 btcpi=$(bitcoin-cli -version |sed -n 's/^.*version //p')
-if [ "$btcpi" = "$btcgit" ]; then
-  btcversion="$btcpi"
-  btcversion_color="${color_green}"
-else
-  btcversion="$btcpi"" Update!"
-  btcversion_color="${color_red}"
-fi
+case "$btcpi" in
+  *"$btcgit"*)
+    btcversion="$btcpi"
+    btcversion_color="${color_green}"
+    ;;
+  *)
+    btcversion="$btcpi"" Update!"
+    btcversion_color="${color_red}"
+    ;;
+esac
 
 # get LND info
 if [ $chain = "test" ]; then


### PR DESCRIPTION
In version 22 of the Bitcoin Core the tag being used is "v22.0" whereas the tag that bitcoin-cli -version is returning is "v22.0.0". This causes the MOTD to falsely claim that the Bitcoin version needs to be updated