### PR TITLE
fix command to retrieve currently installed electrs version

### DIFF
--- a/resources/20-raspibolt-welcome
+++ b/resources/20-raspibolt-welcome
@@ -332,7 +332,7 @@ if [ -z "${electrs_running##*inactive*}" ]; then
   electrsversion_color="${color_red}"
 else
   electrs_running="up"
-  electrspi=$(echo '{"jsonrpc": "2.0", "method": "server.version", "params": [ "raspibolt", "1.4" ], "id": 0}' | netcat 127.0.0.1 50001 -q 1 | jq -r '.result[0]' | awk '{print "v"$2}')
+  electrspi=$(echo '{"jsonrpc": "2.0", "method": "server.version", "params": [ "raspibolt", "1.4" ], "id": 0}' | netcat 127.0.0.1 50001 -q 1 | jq -r '.result[0]' | awk '{print "v"substr($1,9)}')
   if [ "$electrspi" = "$electrsgit" ]; then
     electrsversion="$electrspi"
     electrsversion_color="${color_green}"


### PR DESCRIPTION
The reponse from the electrs api changed and returns `electrs/0.9.1`
the current line for getting the installed version is

`echo '{"jsonrpc": "2.0", "method": "server.version", "params": [ "raspibolt", "1.4" ], "id": 0}' | netcat 127.0.0.1 50001 -q 1 | jq -r '.result[0]' | awk '{print "v"$2}'`
and results in 
`v`

I changed the line to
`echo '{"jsonrpc": "2.0", "method": "server.version", "params": [ "raspibolt", "1.4" ], "id": 0}' | netcat 127.0.0.1 50001 -q 1 | jq -r '.result[0]' | awk '{print "v"substr($1,9)}'`
which returns` v0.9.1 `and can then again compared to the git version