### PR TITLE
Monitoring channel.db size in welcome/motd script

### DIFF
--- a/resources/20-raspibolt-welcome
+++ b/resources/20-raspibolt-welcome
@@ -323,7 +323,7 @@ else
 fi
 
 #get channel.db size
-channel_db_size=$(du -h /mnt/ext/lnd/data/graph/mainnet/channel.db | head -c4)
+channel_db_size=$(du -h /mnt/ext/lnd/data/graph/mainnet/channel.db | awk '{print $1}')
 
 #electrs
 electrs_running=$(systemctl is-active electrs)

--- a/resources/20-raspibolt-welcome
+++ b/resources/20-raspibolt-welcome
@@ -323,7 +323,7 @@ else
 fi
 
 #get channel.db size
-channeldb=$(du -h /mnt/ext/lnd/data/graph/mainnet/channel.db | head -c4)
+channel_db_size=$(du -h /mnt/ext/lnd/data/graph/mainnet/channel.db | head -c4)
 
 #electrs
 electrs_running=$(systemctl is-active electrs)
@@ -409,7 +409,7 @@ ${color_grey}%s
 "${mempool} tx" "${ln_pendinglocal}" \
 "${connections} (📥 ${inbound}/📤 ${outbound})" "${sum_balance}" \
 "${ln_channels_online}" "${ln_channels_total}" \
-"${channeldb}" \
+"${channel_db_size}" \
 "Electrum" "${electrs_running}" "Block Explorer" "${btcrpcexplorer_running}" \
 "${electrsversion}" "${btcrpcexplorerversion}" \
 "${ln_connect_guidance}"

--- a/resources/20-raspibolt-welcome
+++ b/resources/20-raspibolt-welcome
@@ -392,7 +392,7 @@ ${color_red}      ~ (  ${color_yellow}／ /_____${color_red}~      ${color_grey}
 ${color_red}     ( : ${color_yellow}／____   ／${color_red} )     ${color_grey}Mempool %-18s ${color_grey}⏳%14s sat
 ${color_red}      ~ .~ (  ${color_yellow}/ ／${color_red}. ~      ${color_grey}Peers   %-22s ${color_grey}∑%15s sat
 ${color_red}       (  : '${color_yellow}/／${color_red}:  )       ${color_grey}                           ${color_grey}%s/%s channels
-${color_red}        '~ .~${color_yellow}°${color_red}~. ~'        ${color_grey}                           ${color_grey}channel.db size: ${color_green}%s
+${color_red}        '~ .~${color_yellow}°${color_red}~. ~'        ${color_grey}                           ${color_grey}Channel.db size: ${color_green}%s
 ${color_red}            '~'
 ${color_red}                           ${color_yellow}%-20s${electrs_color}%-4s${color_grey}   ${color_yellow}%-18s${color_grey} ${btcrpcexplorer_color}%-4s${color_grey}
 ${color_red}                           ${electrsversion_color}%-26s ${btcrpcexplorerversion_color}%-24s

--- a/resources/20-raspibolt-welcome
+++ b/resources/20-raspibolt-welcome
@@ -322,6 +322,9 @@ else
   lndversion_color="${color_red}"
 fi
 
+#get channel.db size
+channeldb=$(du -h /mnt/ext/lnd/data/graph/mainnet/channel.db | head -c4)
+
 #electrs
 electrs_running=$(systemctl is-active electrs)
 electrs_color="${color_green}"
@@ -389,8 +392,9 @@ ${color_red}      ~ (  ${color_yellow}／ /_____${color_red}~      ${color_grey}
 ${color_red}     ( : ${color_yellow}／____   ／${color_red} )     ${color_grey}Mempool %-18s ${color_grey}⏳%14s sat
 ${color_red}      ~ .~ (  ${color_yellow}/ ／${color_red}. ~      ${color_grey}Peers   %-22s ${color_grey}∑%15s sat
 ${color_red}       (  : '${color_yellow}/／${color_red}:  )       ${color_grey}                           ${color_grey}%s/%s channels
-${color_red}        '~ .~${color_yellow}°${color_red}~. ~'        ${color_grey}
-${color_red}            '~'            ${color_yellow}%-20s${electrs_color}%-4s${color_grey}   ${color_yellow}%-18s${color_grey} ${btcrpcexplorer_color}%-4s${color_grey}
+${color_red}        '~ .~${color_yellow}°${color_red}~. ~'        ${color_grey}                           ${color_grey}channel.db size: ${color_green}%s
+${color_red}            '~'
+${color_red}                           ${color_yellow}%-20s${electrs_color}%-4s${color_grey}   ${color_yellow}%-18s${color_grey} ${btcrpcexplorer_color}%-4s${color_grey}
 ${color_red}                           ${electrsversion_color}%-26s ${btcrpcexplorerversion_color}%-24s
 ${color_grey}For others to connect to this lightning node
 ${color_grey}%s
@@ -405,6 +409,7 @@ ${color_grey}%s
 "${mempool} tx" "${ln_pendinglocal}" \
 "${connections} (📥 ${inbound}/📤 ${outbound})" "${sum_balance}" \
 "${ln_channels_online}" "${ln_channels_total}" \
+"${channeldb}" \
 "Electrum" "${electrs_running}" "Block Explorer" "${btcrpcexplorer_running}" \
 "${electrsversion}" "${btcrpcexplorerversion}" \
 "${ln_connect_guidance}"


### PR DESCRIPTION
**Goal:** This pull-request adds a few line to the `20-raspibolt-welcome` script to display the `channel.db` size in the LND section of the 'message of the day' (motd) system overview.

**Rationales:** When `channel.db` reaches ~1GB on 32-bit OS, LND experienced issues (e.g. [here](https://github.com/lightningnetwork/lnd/issues/4811)). Issues can also be met on 64-bit OSes when reaching larger sizes on low-spec devices (e.g. [here](https://github.com/lightningnetwork/lnd/issues/5705)). Therefore, monitoring the growth of the `channel.db` size is critical.

 **Ideas for future improvements:** For now the variable is a string. Getting an integer instead would allow to create a simple conditional statement to colour-code the line in green, orange and red when below  or above a certain size (e.g. <500MB green, 500-900MB orange, >900MB red)

Thanks in advance for reviewing this proposal.