### PR TITLE
Bonus installation guide: charge-lnd (with cron job, for automated fee policy management)

### DIFF
--- a/raspibolt_80_charge-lnd.md
+++ b/raspibolt_80_charge-lnd.md
@@ -2,7 +2,7 @@
 layout: default
 title: charge-lnd
 parent: Bonus Section
-nav_order: 130
+nav_order: 140
 has_toc: false
 ---
 # Bonus guide: Charge-lnd
@@ -21,25 +21,27 @@ has_toc: false
 
 ## Install charge-lnd
 
-* As recommended in the [repo](https://github.com/accumulator/charge-lnd/blob/master/INSTALL.md#installation), we don't need to have full admin rights to use charge-lnd. The following access rights are used:
-    ** `offchain:read`
-    ** `offchain:write`
-    ** `onchain:read`
-    ** `info:read`
-We can create a suitably limited macaroon by issuing
-  
+* As recommended in the [charge-lnd repository](https://github.com/accumulator/charge-lnd/blob/master/INSTALL.md#installation), we do not need to have full admin rights to use charge-lnd. The following access rights are used:
+  * `offchain:read`
+  * `offchain:write`
+  * `onchain:read`
+  * `info:read`
+
+* We can create (or 'bake') a suitably limited macaroon with the "admin" user
+ 
   ```sh
   $ lncli bakemacaroon offchain:read offchain:write onchain:read info:read --save_to=~/.lnd/data/chain/bitcoin/mainnet/charge-lnd.macaroon
   ```
   
-* We create a charge-lnd user, make it part of the bitcoin group (to be able to interact with LND)  
+* We create a "charge-lnd" user and we make it part of the "bitcoin" group (to be able to interact with LND)  
 
   ```sh
   $ sudo adduser charge-lnd
   $ sudo /usr/sbin/usermod --append --groups bitcoin charge-lnd
   ```
   
-* As charge-lnd user, clone the charge-lnd repository, enter the charge-lnd directory and install the program and required packages using pip3 (don't forget the dot at the end of the pip command!)
+* With the "charge-lnd" user, clone the charge-lnd repository, enter the directory and install the program and required packages using `pip3` (do _not_ forget the dot at the end of the pip command!)
+
   ```sh
   $ sudo su - charge-lnd
   $ git clone https://github.com/accumulator/charge-lnd.git
@@ -47,165 +49,205 @@ We can create a suitably limited macaroon by issuing
   $ pip3 install -r requirements.txt .
   ```
 
-* Test of the installation was successful by running the program with the --help (or -h) flag
+* Test if the installation was successful by running the program with the --help (or -h) flag
 
-```sh
-~/.local/bin/charge-lnd -h
->usage: charge-lnd [-h] [--lnddir LNDDIR] [--grpc GRPC]
->                  [--electrum-server ELECTRUM_SERVER] [--dry-run] [--check]
->                  [-v] -c CONFIG
->
->optional arguments:
->  -h, --help            show this help message and exit
->  --lnddir LNDDIR       (default ~/.lnd) lnd directory
->  --grpc GRPC           (default localhost:10009) lnd gRPC endpoint
->  --electrum-server ELECTRUM_SERVER
->                        (optional, no default) electrum server host:port .
->                        Needed for onchain_fee.
->  --dry-run             Do not perform actions (for testing), print what we
->                        would do to stdout
->  --check               Do not perform actions, only check config file for
->                        valid syntax
->  -v, --verbose         Be more verbose
->  -c CONFIG, --config CONFIG
->                        path to config file
-```
+  ```sh
+  $ ~/.local/bin/charge-lnd -h
+  >usage: charge-lnd [-h] [--lnddir LNDDIR] [--grpc GRPC]
+  >                  [--electrum-server ELECTRUM_SERVER] [--dry-run] [--check]
+  >                  [-v] -c CONFIG
+  >
+  >optional arguments:
+  >  -h, --help            show this help message and exit
+  >  --lnddir LNDDIR       (default ~/.lnd) lnd directory
+  >  --grpc GRPC           (default localhost:10009) lnd gRPC endpoint
+  >  --electrum-server ELECTRUM_SERVER
+  >                        (optional, no default) electrum server host:port .
+  >                        Needed for onchain_fee.
+  >  --dry-run             Do not perform actions (for testing), print what we
+  >                        would do to stdout
+  >  --check               Do not perform actions, only check config file for
+  >                        valid syntax
+  >  -v, --verbose         Be more verbose
+  >  -c CONFIG, --config CONFIG
+  >                        path to config file
+  ```
 
-* We are going to create a simlink to the LND directory.
-We'll place the link in the home directory of the charge-lnd user to match the default LND directory used by charge-lnd (~/.lnd) 
-```sh
-$ ln -s /mnt/ext/lnd/ /home/charge-lnd/.lnd
-```
+* We are going to create a simlink to the LND directory. We'll place the link in the home directory of the "charge-lnd" user to match the default LND directory used by charge-lnd (~/.lnd) 
+
+  ```sh
+  $ ln -s /mnt/ext/lnd/ /home/charge-lnd/.lnd
+  ```
 
 ## Configuration file
 
 * Create a configuration file that we will call charge-lnd.config
-```sh
-$ nano charge-lnd.config
-```
 
-* For this example, we will use a policy that 1) defines some default parameters; 2) then starts by looking at channels with very low outbound (below 200,000 sats) to apply a very large base fee that will prevent any attempted forward through the channel (and therefore avoid failures); then 3) ignores some channels that we want to deal with manually (e.g. a large liquidity sink); and 4) applies a proportional fee rate between 50 and 200 ppm (based on balance ratio) for the remaining channels.
-* Do change the policy in accordance with your own strategy and needs! All the options are listed and described [here](https://github.com/accumulator/charge-lnd)
-```ini
-# place holder for your defaults for your fee policies
-# no strategy, so this only sets some defaults
-[mydefaults]
-min_fee_ppm_delta = 20
-min_htlc_msat = 1000
-max_htlc_msat_ratio = 1
-time_lock_delta = 40
+  ```sh
+  $ nano charge-lnd.config
+  ```
 
-# 9999BaseFee should be evaluated first before other fees are set
-# if local balance is <200,000 sats, increase fees very high
-[1-#9999BaseFee_avoid_failed_forwards]
-chan.max_local_balance = 200000
-strategy = static
-base_fee_msat = 9999000
+* For this example, we will use a policy that: 
+  1. Defines some default parameters
+  2. Then starts by looking at channels with very low outbound to apply a very large base fee that will prevent any attempted forward through the channel (and therefore avoid failures)
+  3. Then ignores some channels that we want to deal with manually (e.g. a large liquidity sink)
+  4. And finally apply a fixed fee rate for two groups of channels
+  
+* Warning: The policy below is just an example, _do_ change the policy according to your own strategy and needs! All the options are listed and described [here](https://github.com/accumulator/charge-lnd)
 
-# Ignore some channels
-[2-ignore_two_channels]
-node.id = <node_pubkey_1>,
+  ```ini
+  #################################################
+  # Charge-lnd - Automatic fee policy adjustement #
+  #################################################
+
+  ## COMMANDS TO TEST YOUR FEE STRATEGY
+  # ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --check
+  # ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --dry-run
+
+  ## FEE STRATEGY
+
+  [1_defaults]
+  # place holder for your defaults for your fee policies
+  # no strategy, so this only sets some defaults
+  base_fee_msat = 1000
+  min_fee_ppm_delta = 20
+  min_htlc_msat = 1000
+  max_htlc_msat_ratio = 1
+  time_lock_delta = 40
+
+  [2_9999_basefee_policy]
+  # '9999BaseFee' should be evaluated first before other fees are set
+  # e.g. if local balance is <500,000 sats, increase base fees very high
+  chan.max_local_balance = 500000
+  strategy = static
+  base_fee_msat = 9999000
+
+  [3_ignore_policy]
+  # This policy is for ignoring specific nodes (e.g. a LOOP channel that we want to control manually)
+  # The pubkey of the choosen nodes have to be listed below, separated with a comma
+  node.id = <node_pubkey_1>,
 	<node_pubkey_2>
-strategy = ignore
+  strategy = ignore
 
-# Proportional strategy for all other channels
-[3-proportional_for_remaining_channels]
-strategy = proportional
-base_fee_msat = 0
-min_fee_ppm = 50
-max_fee_ppm = 200
-```
+  [4_low_fees_policy]
+  node.id = <node_pubkey_3>,
+	<node_pubkey_4>,
+	<node_pubkey_5>
+  strategy = static
+  fee_ppm = 50
+  
+  [5_high_fees_policy]
+  node.id = <node_pubkey_6>,
+	<node_pubkey_7>
+  strategy = static
+  fee_ppm = 200
+  ```
+
 * We can first test if the syntax is correct or if it contains some errors using the --check option.
 We also have to indicate where the config file is located using the --config (or -c) option
 
-```sh
-$  ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --check
-> Configuration file is valid
-```
+  ```sh
+  $  ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --check
+  > Configuration file is valid
+  ```
 
 * Then we can do a dry-run test which will print out what changes the program would apply of it was to be run.
 A small report will be displayed for each channel policy that should be updated.
 Adding the --verbose (or -v) option would add aditional information such as if the channel is enabled or disabled.
-```sh
-$  ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --dry-run
-> 700435x675x2  [<noda_alias>|<node_pukkey>]
->  policy:          1-stop_routing
->  strategy:        static
->  base_fee_msat:   0 ➜ 9999000
->  min_htlc_msat:   1000
->  max_htlc_msat:   1000000000
->  time_lock_delta: 40
->  ...
-```
+
+  ```sh
+  $  ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --dry-run
+  > 123456x123x1  [<noda_alias>|<node_pukkey>]
+  >  policy:          2_9999_basefee_policy
+  >  strategy:        static
+  >  base_fee_msat:   0 ➜ 9999000
+  >  [...]
+  ```
 
 * Check each channel to see if the proposed updates are the intended one.
 If not, amend the charge-lnd config and re-do dry-run tests until you arrive to the desired results
 
 * Once we are happy with our fee policy and logic, we can manually apply it to our node by running the same command but without the --dry-run test.
 Then exit the charge-lnd user.
-```sh
-$  ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config
-$ exit
-```
+
+  ```sh
+  $  ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config
+  $ exit
+  ```
 
 * Double-check the fee policy on all your channels to ensure that you are happy with the changes!
 
 ## Automatic fee updates
 
-We can make the script run automatically at regular time intervals by using a cron job. For example, we could run the charge-lnd program every day at the 21st minute of every hour.
+We can make the script run automatically at regular time intervals by using a cron job. For example, we could run the charge-lnd program every 12 hours.
+
+Warning: It is not in your interest, nor in the interest of the wider network, to set up very short intervals between each policay change. Frequent channel policy update spams the LN gossip network and results in less accurate LN graphs overall as it takes a long time for a policy update to reach most of the nodes in the network.
 
 * We the admin user, create and edit (option -e) the crontab file of the charge-lnd user (option -u). 
 If asked, select the /bin/nano text editor (type 1 and enter)
-```sh
-$ sudo crontab -u charge-lnd -e
-```
+
+  ```sh
+  $ sudo crontab -u charge-lnd -e
+  ```
 
 * At the end of the file, paste the following lines. Then save (Ctrl+o) and exit (Ctrl+x)
-```ini
-# Run charge-lnd every four hours, every day; and log the updates in the /tmp/charge-lnd.log log file
-21 */4 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/charge-lnd/charge-lnd/charge-lnd.config > /tmp/charge-lnd.log 2>&1; date >> /tmp/charge-lnd.log
-```
-* The stars and numbers at the start defines the interval at which the job will be run. You can double-check it by using this online tool: [https://crontab.guru](https://crontab.guru/#21_*/4_*_*_*)
-* `/home/umbrel/.local/bin/charge-lnd -c /home/umbrel/charge-lnd/myconfig` is the command to be run and where to find it (its path) together with the required option(s) (here the location of the configuration file)
-* `> /tmp/charge-lnd.log 2>&1; date >> /tmp/charge-lnd.log` records the updates in a charge-lnd.log log file, including the Standard Error and Standard Out and with a timestamp
+
+  ```ini
+  ##########################################
+  # 1 - Fee policy updates with charge-lnd #
+  ##########################################
+
+  # Run charge-lnd every 12 hours at the 21st minute; and log the updates in the /tmp/my_charge-lnd.log log file
+  21 */12 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/charge-lnd/charge-lnd/charge-lnd.config > /tmp/my_charge-lnd.log 2>&1; date >> /tmp/my_charge-lnd.log 
+  ```
+
+  * The stars and numbers at the start defines the interval at which the job will be run. You can double-check it by using this online tool: [https://crontab.guru](https://crontab.guru/#21_*/4_*_*_*). 
+  * `/home/umbrel/.local/bin/charge-lnd -c /home/umbrel/charge-lnd/myconfig` is the command to be run and where to find it (its path) together with the required option(s) (here the location of the configuration file). 
+  * `> /tmp/charge-lnd.log 2>&1; date >> /tmp/charge-lnd.log` records the updates in a charge-lnd.log log file, including the Standard Error and Standard Out and with a timestamp.
 
 ## Checking the logs
 
-If you need to check the log files
+If you need to check the log files:
 
-* Use less to read the entire log file. Type g to go the start, G to the end, use the arrows to move up and down and exit by pressing q.
-You can search for a specific string by typing ? followed by the string to be searched (e.g. a node alias) and then press enter.
-```sh
-$ less /tmp/charge-lnd.log
-```
+* Use `less` to read the entire log file. Type "g" to go the start of the log, "G" to the end, use the arrows to move up and down and exit by pressing "q".
+* You can search for a specific string by typing "?" followed by the string to be searched (e.g. a node alias) and then press enter.
+
+  ```sh
+  $ less /tmp/my_charge-lnd.log
+  ```
 
 * To look for updates of a specific channel
-```sh
-$ cat /tmp/charge-lnd.log | grep -A 7 <node_alias>
-```
+
+  ```sh
+  $ cat /tmp/my_charge-lnd.log | grep -A 7 <node_alias>
+  ```
 
 # Upgrade
 
 * Let's check what is the latest available version at [https://github.com/accumulator/charge-lnd/releases](https://github.com/accumulator/charge-lnd/releases) and let's find what version of charge-lnd we are running
-```sh
-$ sudo su - charge-lnd
-$ pip3 show charge-lnd
-> Name: charge-lnd
-> Version: 0.2.5
-```
+
+  ```sh
+  $ sudo su - charge-lnd
+  $ pip3 show charge-lnd
+  > Name: charge-lnd
+  > Version: 0.2.5
+  ```
 
 * If a newer version exists (e.g. v0.X.X)
-```sh
-$ git fetch
-$ git checkout v0.X.X
-$ python -m pip install --upgrade requirements.txt .
-```
+  
+  ```sh
+  $ git fetch
+  $ git checkout v0.X.X
+  $ python -m pip install --upgrade requirements.txt .
+  ```
 
 # Uninstall
 
 If you want to uninstall charge-lnd:
 
-* With the root user, delete the charge-lnd user
-```sh
-$ userdel -r charge-lnd
-```
+* Log in with the "root" user and delete the "charge-lnd" user
+
+  ```sh
+  $ sudo su -
+  $ userdel -r charge-lnd
+  ```

--- a/raspibolt_80_charge-lnd.md
+++ b/raspibolt_80_charge-lnd.md
@@ -154,31 +154,56 @@ $ exit
 
 We can make the script run automatically at regular time intervals by using a cron job. For example, we could run the charge-lnd program every day at the 21st minute of every hour.
 
-* We the admin user, open the root user crontab file. 
+* We the admin user, create and edit (option -e) the crontab file of the charge-lnd user (option -u). 
 If asked, select the /bin/nano text editor (type 1 and enter)
 ```sh
-$ sudo crontab -e
+$ sudo crontab -u charge-lnd -e
 ```
 
 * At the end of the file, paste the following lines. Then save (Ctrl+o) and exit (Ctrl+x)
 ```ini
-# Run charge-lnd every hour, every day and log the updates in the /tmp/charge-lnd.log log file
-21 */1 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/charge-lnd/charge-lnd/charge-lnd.config > /tmp/charge-lnd.log 2>&1; date >> /tmp/charge-lnd.log
+# Run charge-lnd every four hours, every day; and log the updates in the /tmp/charge-lnd.log log file
+21 */4 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/charge-lnd/charge-lnd/charge-lnd.config > /tmp/charge-lnd.log 2>&1; date >> /tmp/charge-lnd.log
 ```
 * The stars and numbers at the start defines the interval at which the job will be run. You can double-check it by using this online tool: [https://crontab.guru](https://crontab.guru/#21_*/4_*_*_*)
-* `/home/umbrel/.local/bin/charge-lnd -c /home/umbrel/charge-lnd/myconfig` is the program to be run and where to find it (its path) together with the required option (here the location of the configuration file)
+* `/home/umbrel/.local/bin/charge-lnd -c /home/umbrel/charge-lnd/myconfig` is the command to be run and where to find it (its path) together with the required option(s) (here the location of the configuration file)
 * `> /tmp/charge-lnd.log 2>&1; date >> /tmp/charge-lnd.log` records the updates in a charge-lnd.log log file, including the Standard Error and Standard Out and with a timestamp
 
 ## Checking the logs
 
 If you need to check the log files
 
-* Print the content of the log file (e.g. the last 100 lines only)
+* Use less to read the entire log file. Type g to go the start, G to the end, use the arrows to move up and down and exit by pressing q.
+You can search for a specific string by typing ? followed by the string to be searched (e.g. a node alias) and then press enter.
 ```sh
-$ cat -n 100 /tmp/charge-lnd.log
+$ less /tmp/charge-lnd.log
 ```
 
 * To look for updates of a specific channel
 ```sh
-$ cat -n 100 /tmp/charge-lnd.log | grep -A 7 <node_alias>
+$ cat /tmp/charge-lnd.log | grep -A 7 <node_alias>
+```
+
+# Upgrade
+
+* Let's check what is the latest available version at [https://github.com/accumulator/charge-lnd/releases](https://github.com/accumulator/charge-lnd/releases) and let's find what version of charge-lnd we are running
+```sh
+$ sudo su - charge-lnd
+$ pip3 show charge-lnd
+> Name: charge-lnd
+> Version: 0.2.4
+```
+
+* If a newer version exists
+```sh
+$ pip3 install --upgrade charge-lnd
+```
+
+# Uninstall
+
+If you want to uninstall charge-lnd:
+
+* With the root user, delete the charge-lnd user
+```sh
+$ userdel -r charge-lnd
 ```

--- a/raspibolt_80_charge-lnd.md
+++ b/raspibolt_80_charge-lnd.md
@@ -1,0 +1,6 @@
+$ sudo adduser charge-lnd
+$ sudo /usr/sbin/usermod --append --groups bitcoin charge-lnd
+$ sudo su - charge-lnd
+$ git clone https://github.com/accumulator/charge-lnd
+$ cd charge-lnd
+$ pip3 install -r requirements.txt

--- a/raspibolt_80_charge-lnd.md
+++ b/raspibolt_80_charge-lnd.md
@@ -191,12 +191,14 @@ $ cat /tmp/charge-lnd.log | grep -A 7 <node_alias>
 $ sudo su - charge-lnd
 $ pip3 show charge-lnd
 > Name: charge-lnd
-> Version: 0.2.4
+> Version: 0.2.5
 ```
 
-* If a newer version exists
+* If a newer version exists (e.g. v0.X.X)
 ```sh
-$ pip3 install --upgrade charge-lnd
+$ git fetch
+$ git checkout v0.X.X
+$ python -m pip install --upgrade requirements.txt .
 ```
 
 # Uninstall

--- a/raspibolt_80_charge-lnd.md
+++ b/raspibolt_80_charge-lnd.md
@@ -1,6 +1,104 @@
-$ sudo adduser charge-lnd
-$ sudo /usr/sbin/usermod --append --groups bitcoin charge-lnd
-$ sudo su - charge-lnd
-$ git clone https://github.com/accumulator/charge-lnd
-$ cd charge-lnd
-$ pip3 install -r requirements.txt
+---
+layout: default
+title: charge-lnd
+parent: Bonus Section
+nav_order: 130
+has_toc: false
+---
+# Bonus guide: Charge-lnd
+
+*Difficulty: simple*
+
+[Charge-lnd](https://github.com/accumulator/charge-lnd) is a simple policy based fee manager for LND.
+
+*Requirements:*
+
+* LND (or LND as part of Lightning Terminal/litd)
+
+*Acknowledgments:*
+
+* This guide is modified from the [manual install guide](https://gist.github.com/openoms/823f99d1ab6e1d53285e489f7ba38602) for the Raspiblitz by @openoms.
+
+## Install charge-lnd
+
+* As recommended in the [repo](https://github.com/accumulator/charge-lnd/blob/master/INSTALL.md#installation), we don't need to have full admin rights to use charge-lnd. The following access rights are used:
+    ** `offchain:read`
+    ** `offchain:write`
+    ** `onchain:read`
+    ** `info:read`
+We can create a suitably limited macaroon by issuing
+  
+  ```sh
+  $ lncli bakemacaroon offchain:read offchain:write onchain:read info:read --save_to=~/.lnd/data/chain/bitcoin/mainnet/charge-lnd.macaroon
+  ```
+  
+* We create a charge-lnd user, make it part of the bitcoin group (to be able to interact with LND)  
+
+  ```sh
+  $ sudo adduser charge-lnd
+  $ sudo /usr/sbin/usermod --append --groups bitcoin charge-lnd
+  ```
+  
+* As charge-lnd user, clone the charge-lnd repository, enter the charge-lnd directory and install the program and required packages using pip3 (don't forget the dot at the end of the pip command!)
+  ```sh
+  $ sudo su - charge-lnd
+  $ git clone https://github.com/accumulator/charge-lnd.git
+  $ cd charge-lnd
+  $ pip3 install -r requirements.txt .
+  ```
+
+## Configuration file
+
+* Create a configuration file that we will call charge-lnd.config
+
+```sh
+$ nano charge-lnd.config
+```
+
+* We can test the program by using a very simple config file
+
+```sh
+$ nano charge.config
+```
+
+* As an example, we are going to choose one channel and set up a fee policy that changes proportinally with the channel balance ratio
+* The channel balance ratio is calculated as local_capacity/total_capacity. So the ratio is equal to 1 when all the capacity is on our side (e.g. after initiating a channel opening to a node) and 0 whenn all the capacity is remote.
+* Let's choose a channel that we want to use as a test for this fee policy. Find the channel ID (a 18 digits number)
+* Paste the folliwing in the charge.config file. Change the CHANNEL_IDEA with your own selected channel ID. You can also chosse your own min and max fee rates (in ppm). Then exit with Ctrl+C
+
+```sh
+[ignored_channels]
+# don't let charge-lnd set fees (strategy=ignore) for channels to/from the specified nodes
+node.id = [NODE_1_PUKEY],
+  [NODE_2_PUBKEY],
+  [NODE_3_PUBKEY]
+
+
+[proportional]
+# 'proportional' can also be used to auto balance (lower fee rate when low remote balance & higher rate when higher remote balance)
+# fee_ppm decreases linearly with the channel balance ratio (min_fee_ppm when ratio is 1, max_fee_ppm when ratio is 0)
+chan.id = [CHANNEL_ID]
+
+strategy = proportional
+min_fee_ppm = 10
+max_fee_ppm = 200
+```
+
+* Exit the bitcoin user
+
+```sh
+$ exit
+```
+
+
+## First run
+
+* We are now ready to run the program for the first time 
+
+```sh
+$ sudo -u bitcoin /home/bitcoin/.local/bin/charge-lnd -c /home/bitcoin/charge-lnd/charge.config
+```
+
+(same in a cronjob)
+
+

--- a/raspibolt_80_charge-lnd.md
+++ b/raspibolt_80_charge-lnd.md
@@ -181,7 +181,7 @@ Then exit the charge-lnd user.
 
 ## Automatic fee updates
 
-We can make the script run automatically at regular time intervals by using a cron job. For example, we could run the charge-lnd program every 12 hours.
+We can make the script run automatically at regular time intervals by using a cron job. For example, we could run the charge-lnd program every 2 hours.
 
 Warning: It is not in your interest, nor in the interest of the wider network, to set up very short intervals between each policay change. Frequent channel policy update spams the LN gossip network and results in less accurate LN graphs overall as it takes a long time for a policy update to reach most of the nodes in the network.
 
@@ -199,8 +199,8 @@ If asked, select the /bin/nano text editor (type 1 and enter)
   # 1 - Fee policy updates with charge-lnd #
   ##########################################
 
-  # Run charge-lnd every 12 hours at the 21st minute; and log the updates in the /tmp/my_charge-lnd.log log file
-  21 */12 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/charge-lnd/charge-lnd/charge-lnd.config > /tmp/my_charge-lnd.log 2>&1; date >> /tmp/my_charge-lnd.log 
+  # Run charge-lnd every 2 hours at the 21st minute; and log the updates in the /tmp/my_charge-lnd.log log file
+  21 */2 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/charge-lnd/charge-lnd/charge-lnd.config > /tmp/my_charge-lnd.log 2>&1; date >> /tmp/my_charge-lnd.log 
   ```
 
   * The stars and numbers at the start defines the interval at which the job will be run. You can double-check it by using this online tool: [https://crontab.guru](https://crontab.guru/#21_*/4_*_*_*). 

--- a/raspibolt_80_charge-lnd.md
+++ b/raspibolt_80_charge-lnd.md
@@ -177,6 +177,8 @@ Then exit the charge-lnd user.
 
 * Double-check the fee policy on all your channels to ensure that you are happy with the changes!
 
+🔍: _To see all the possible policy types and options and some examples, check the charge-lnd [Github page](https://github.com/accumulator/charge-lnd#charge-lnd)._
+
 ## Automatic fee updates
 
 We can make the script run automatically at regular time intervals by using a cron job. For example, we could run the charge-lnd program every 12 hours.

--- a/raspibolt_80_charge-lnd.md
+++ b/raspibolt_80_charge-lnd.md
@@ -154,9 +154,10 @@ $ exit
 
 We can make the script run automatically at regular time intervals by using a cron job. For example, we could run the charge-lnd program every day at the 21st minute of every hour.
 
-* We the admin user, open the admin user crontab file
+* We the admin user, open the root user crontab file. 
+If asked, select the /bin/nano text editor (type 1 and enter)
 ```sh
-$ crontab -e
+$ sudo crontab -e
 ```
 
 * At the end of the file, paste the following lines. Then save (Ctrl+o) and exit (Ctrl+x)

--- a/raspibolt_80_charge-lnd.md
+++ b/raspibolt_80_charge-lnd.md
@@ -17,7 +17,7 @@ has_toc: false
 
 *Acknowledgments:*
 
-* This guide is modified from the [manual install guide](https://gist.github.com/openoms/823f99d1ab6e1d53285e489f7ba38602) for the Raspiblitz by @openoms.
+* This guide was built based on the guides by The Count on [nullcount.com](https://nullcount.com/install-charge-lnd-routing-fees-on-autopilot/) and by the [Plebnet Wiki guide](https://plebnet.wiki/wiki/Fees_And_Profitability#Installing_Charge-Lnd).
 
 ## Install charge-lnd
 


### PR DESCRIPTION
**Goal:** This is a bonus guide that explains how to install and set up charge-lnd, a simple policy-based fee manager for LND, together with a cron job to run it regularly and automate as much as possible the fee policy management.

**Rationales:** This guide belongs to a series of bonus installation guides to help the node operator to manage its LN node and channels (e.g. Ride The Lightning, Balance of Satoshis etc). Charge-lnd is a popular program used by the LN community to automate the management of channel fee policies. The guide shows how to install charge-lnd, gives an example of config file (i.e. a set of policies) and explains how to create a cron job a a log file to regularly run the program (every 12 hours to avoid spamming the gossip network) and how to upgrade and uninstall it.

Thanks in advance for reviewing this proposal.