### PR TITLE
Next electrs release will use `log_filters` instead of `verbose` config

### DIFF
--- a/raspibolt_50_electrs.md
+++ b/raspibolt_50_electrs.md
@@ -141,7 +141,7 @@ The whole process takes about 30 minutes.
   index_lookup_limit = 1000
 
   # Logging
-  verbose = 2
+  log_filters = "INFO"
   timestamp = true
   ```
 


### PR DESCRIPTION
Following https://github.com/romanz/electrs/pull/615.