### PR TITLE
add 404 error page

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,13 @@
+---
+permalink: /404.html
+title: RaspiBolt 404
+nav_exclude: true
+---
+
+# 404: Page not found
+
+## Damn, this link wasn't as immutable as Bitcoin.
+
+<br />
+
+<-- Check the navigation.


### PR DESCRIPTION
With the move to the new organization and upcoming page
reorganization, a proper 404 "page not found" error page is
helpful.

The main advantage is that it includes the navigation
sidebar, so even if a specific page is not available, visitors
can quickly find what they're looking for.