### PR TITLE
add link to https://v2.raspibolt.org

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,6 +4,7 @@ title: Home
 nav_order: 1
 ---
 <!-- markdownlint-disable MD014 MD022 MD025 MD033 MD040 -->
+{% include_relative include_metatags.md %}
 
 ![RaspiBolt Logo](images/raspibolt3-logo.png)
 
@@ -103,7 +104,7 @@ We recommend setting up the RaspiBolt from scratch, but you can then copy over e
 
 ## Looking for an older version of this guide?
 
-If you're looking for an older version of this guide, you can still check out the archived source files for [version 1](https://github.com/raspibolt/raspibolt/blob/raspibolt-v1-deprecated/index.md){:target="_blank"} and [version 2](https://github.com/raspibolt/raspibolt/blob/raspibolt-v2-deprecated/index.md){:target="_blank"}.
+If you're looking for an older version of this guide, you can still check out the archived source files for [version 1](https://github.com/raspibolt/raspibolt/blob/raspibolt-v1-deprecated/index.md){:target="_blank"} and [version 2](https://v2.raspibolt.org){:target="_blank"}.
 
 <br /><br />
 


### PR DESCRIPTION
The MD source files are not very convenient to use as an archive of older versions. The deprecated version 2 of the RaspiBolt guide is now published at https://v2.raspibolt.org, and this commit changes the link on the homepage.