### PR TITLE
add pull request and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### Location in guide
+Link to the corresponding page and section on <https://raspibolt.org>
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Environment
+ - Hardware platform: [e.g. Raspberry Pi 4, Odroid, ... ]
+ - Operating system: [e.g, Raspberry Pi OS 64bit, Debian 11, ... ]
+ - Version: [ output of `lsb_release -d` ]
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE REQ] "
+labels: feature request
+assignees: ''
+
+---
+
+### What & why
+
+Is your feature request related to a problem, or a new addition to the guide? Provide a clear and concise description of what you'd like added to the RaspiBolt guide. If possible, please phrase it as a user story:
+
+> As a [description of user], I want [functionality] so that [benefit].
+
+### How
+
+Describe the solution you're thinking of. Provide a clear and concise description of what you want to happen. Did you consider alternative options?
+
+### Additional context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,24 @@
+---
+name: Support question
+about: Ask for help if you're stuck
+labels: support
+assignees: ''
+
+---
+
+### Describe the issue
+A clear and concise description of where you're stuck in the guide. What are you trying to do, and how is it not working?
+
+### Location in guide
+Link to the corresponding page and section on <https://raspibolt.org>
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Environment
+ - Hardware platform: [e.g. Raspberry Pi 4, Odroid, ... ]
+ - Operating system: [e.g, Raspberry Pi OS 64bit, Debian 11, ... ]
+ - Version: [ output of `lsb_release -d` ]
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+#### What
+
+What is the reason of this change?
+
+### Why
+
+Why is this change important?
+
+#### How
+
+How was this change accomplished?
+
+#### Scope
+
+- [ ] significant change to core configuration
+- [ ] independent bonus guide
+- [ ] simple bug fix
+
+Fixes # (link issue)
+
+#### Test & maintenance
+
+How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?
+
+#### Animated GIF (optional)
+
+Add some snazz if you feel like it :)


### PR DESCRIPTION
Support in issues and collaboration through pull requests was done
without proper guidance. Providing a template for both encourages
the inclusion of essential information.