### PR TITLE
Avoid unnecessary nginx / tor restarts, reload is enough

### DIFF
--- a/btcrpcexplorer.md
+++ b/btcrpcexplorer.md
@@ -89,11 +89,11 @@ Now we can add the RTL configuration.
   }
   ```
 
-* Test NGINX configuration and restart the service
+* Test and reload NGINX configuration
 
   ```sh
   $ sudo nginx -t
-  $ sudo systemctl restart nginx
+  $ sudo systemctl reload nginx
   ```
 
 * Configure the firewall to allow incoming HTTPS requests
@@ -304,10 +304,10 @@ You can easily do so by adding a Tor hidden service on the RaspiBolt and accessi
   HiddenServicePort 80 127.0.0.1:3002
   ```
 
-* Restart Tor and get your connection address.
+* Reload Tor configuration and get your connection address.
 
   ```sh
-  $ sudo systemctl restart tor
+  $ sudo systemctl reload tor
   $ sudo cat /var/lib/tor/hidden_service_btcrpcexplorer/hostname
   > abcdefg..............xyz.onion
   ```

--- a/electrs.md
+++ b/electrs.md
@@ -69,11 +69,11 @@ Now we can add the Electrs configuration.
   }
   ```
 
-* Test the NGINX configuration and restart the service
+* Test and reload NGINX configuration
 
   ```sh
   $ sudo nginx -t
-  $ sudo systemctl restart nginx
+  $ sudo systemctl reload nginx
   ```
 
 * Configure the firewall to allow incoming requests
@@ -287,10 +287,10 @@ Note that the remote device needs to have Tor installed as well.
   HiddenServicePort 50002 127.0.0.1:50002
   ```
 
-* Restart Tor and get your connection address.
+* Reload Tor configuration and get your connection address.
 
   ```sh
-  $ sudo systemctl restart tor
+  $ sudo systemctl reload tor
   $ sudo cat /var/lib/tor/hidden_service_electrs/hostname
   > abcdefg..............xyz.onion
   ```

--- a/privacy.md
+++ b/privacy.md
@@ -72,10 +72,10 @@ We need to enable Tor to accept instructions through its control port, with the 
   CookieAuthFileGroupReadable 1
   ```
 
-* Restart Tor to activate the modifications
+* Reload Tor configuration to activate the modifications
 
   ```sh
-  $ sudo systemctl restart tor
+  $ sudo systemctl reload tor
   ```
 
 * Allow the user "bitcoin" to configure Tor directly
@@ -111,10 +111,10 @@ This makes "calling home" very easy, without the need to configure anything on y
   HiddenServicePort 22 127.0.0.1:22
   ```
 
-* Restart Tor and look up your Tor connection address
+* Reload Tor configuration and look up your Tor connection address
 
   ```sh
-  $ sudo systemctl restart tor
+  $ sudo systemctl reload tor
   $ sudo cat /var/lib/tor/hidden_service_sshd/hostname
   > abcdefg..............xyz.onion
   ```

--- a/rtl.md
+++ b/rtl.md
@@ -62,11 +62,11 @@ Now we can add the RTL configuration.
   }
   ```
 
-* Test NGINX configuration and restart the service
+* Test and reload NGINX configuration
 
   ```sh
   $ sudo nginx -t
-  $ sudo systemctl restart nginx
+  $ sudo systemctl reload nginx
   ```
 
 * Configure firewall to allow incoming HTTPS requests:
@@ -252,10 +252,10 @@ You can easily add a Tor hidden service on the RaspiBolt and access the Ride the
   HiddenServicePort 80 127.0.0.1:3000
   ```
 
-  Restart Tor and get your connection address.
+  Update Tor configuration changes and get your connection address.
 
   ```sh
-  $ sudo systemctl restart tor
+  $ sudo systemctl reload tor
   $ sudo cat /var/lib/tor/hidden_service_rtl/hostname
   > abcefg...................zyz.onion
   ```


### PR DESCRIPTION
There is no need to restart neither nginx nor tor on each configuration change.