### PR TITLE
Recommend optional DIY steel backup for LND 24 words

### DIFF
--- a/lnd.md
+++ b/lnd.md
@@ -284,7 +284,7 @@ This piece of paper is all an attacker needs to completely empty your on-chain w
 Do not store it on a computer.
 Do not take a picture with your mobile phone.
 **This information should never be stored anywhere in digital form.**
-  * (optional, but recommended) Record these words in steel to render the backup resistant to fire, water and other hazards that could easily destroy the paper backup. In the spirit of the RaspiBolt DIY approach, a good DIY solution for this is to stamp the words into steel washers and store the washers on bolt secured by a wingnut. This solution uses only off-the-shelf components and therefore does not reveal to any merchants that you might own bitcoins. For a full guide, check out the following article: [https://www.econoalchemist.com/post/backup](https://www.econoalchemist.com/post/backup){:target="_blank"} *(note: the jig is optional, no need to buy it if you don't have a 3D printer)*.
+  * (optional) Record these words in steel to render the backup resistant to fire, water and other hazards that could easily destroy the paper backup. In the spirit of the RaspiBolt DIY approach, a good DIY solution for this is to stamp the words into steel washers and store the washers on bolt secured by a wingnut. This solution uses only off-the-shelf components and therefore does not reveal to any merchants that you might own bitcoins. For a full guide, check out the following article: [https://www.econoalchemist.com/post/backup](https://www.econoalchemist.com/post/backup){:target="_blank"} *(note: the jig is optional, no need to buy it if you don't have a 3D printer)*.
 
 * Exit the user "lnd" user session, and then exit the second SSH session altogether
 

--- a/lnd.md
+++ b/lnd.md
@@ -286,7 +286,7 @@ For this, the Static Channel Backup stored at `/data/lnd-backup/channel.backup` 
 
 🚨 This information must be kept secret at all times.
 * **Write these 24 words down manually on a piece of paper and store it in a safe place.** 
-You can use a simple piece of paper ([or print out a proper backup card](https://shiftcrypto.ch/backupcard/backupcard_print.pdf){:target="_blank"}), or even stamp the seed words into metal (e.g. [check this DIY guide](https://www.econoalchemist.com/post/backup){:target="_blank"}).
+You can use a simple piece of paper, write them on a proper [backup card](https://shiftcrypto.ch/backupcard/backupcard_print.pdf){:target="_blank"}), or even stamp the seed words into metal (see this [DIY guide](https://www.econoalchemist.com/post/backup){:target="_blank"}).
 This piece of paper is all an attacker needs to completely empty your on-chain wallet!
 Do not store it on a computer.
 Do not take a picture with your mobile phone.

--- a/lnd.md
+++ b/lnd.md
@@ -279,12 +279,12 @@ The current state of your channels, however, cannot be recreated from this seed.
 For this, the Static Channel Backup stored at `/data/lnd-backup/channel.backup` is updated continuously.
 
 🚨 This information must be kept secret at all times.
-* **Write these 24 words down manually on a piece of paper and store it in a safe place.**
+* **Write these 24 words down manually on a piece of paper and store it in a safe place.** 
+You can use a simple piece of paper ([or print out a proper backup card](https://shiftcrypto.ch/backupcard/backupcard_print.pdf){:target="_blank"}), or even stamp the seed words into metal (e.g. check this [DIY guide](https://www.econoalchemist.com/post/backup){:target="_blank"}).
 This piece of paper is all an attacker needs to completely empty your on-chain wallet!
 Do not store it on a computer.
 Do not take a picture with your mobile phone.
 **This information should never be stored anywhere in digital form.**
-  * (optional) Record these words in steel to render the backup resistant to fire, water and other hazards that could easily destroy the paper backup. In the spirit of the RaspiBolt DIY approach, a good DIY solution for this is to stamp the words into steel washers and store the washers on bolt secured by a wingnut. This solution uses only off-the-shelf components and therefore does not reveal to any merchants that you might own bitcoins. For a full guide, check out the following article: [https://www.econoalchemist.com/post/backup](https://www.econoalchemist.com/post/backup){:target="_blank"} *(note: the jig is optional, no need to buy it if you don't have a 3D printer)*.
 
 * Exit the user "lnd" user session, and then exit the second SSH session altogether
 

--- a/lnd.md
+++ b/lnd.md
@@ -280,7 +280,7 @@ For this, the Static Channel Backup stored at `/data/lnd-backup/channel.backup` 
 
 🚨 This information must be kept secret at all times.
 * **Write these 24 words down manually on a piece of paper and store it in a safe place.** 
-You can use a simple piece of paper ([or print out a proper backup card](https://shiftcrypto.ch/backupcard/backupcard_print.pdf){:target="_blank"}), or even stamp the seed words into metal (e.g. check this [DIY guide](https://www.econoalchemist.com/post/backup){:target="_blank"}).
+You can use a simple piece of paper ([or print out a proper backup card](https://shiftcrypto.ch/backupcard/backupcard_print.pdf){:target="_blank"}), or even stamp the seed words into metal (e.g. [check this DIY guide](https://www.econoalchemist.com/post/backup){:target="_blank"}).
 This piece of paper is all an attacker needs to completely empty your on-chain wallet!
 Do not store it on a computer.
 Do not take a picture with your mobile phone.

--- a/lnd.md
+++ b/lnd.md
@@ -279,11 +279,12 @@ The current state of your channels, however, cannot be recreated from this seed.
 For this, the Static Channel Backup stored at `/data/lnd-backup/channel.backup` is updated continuously.
 
 🚨 This information must be kept secret at all times.
-**Write these 24 words down manually on a piece of paper and store it in a safe place.**
+* **Write these 24 words down manually on a piece of paper and store it in a safe place.**
 This piece of paper is all an attacker needs to completely empty your on-chain wallet!
 Do not store it on a computer.
 Do not take a picture with your mobile phone.
 **This information should never be stored anywhere in digital form.**
+  * (optional, but recommended) Record these words in steel to render the backup resistant to fire, water and other hazards that could easily destroy the paper backup. In the spirit of the RaspiBolt DIY approach, a good DIY solution for this is to stamp the words into steel washers and store the washers on bolt secured by a wingnut. This solution uses only off-the-shelf components and therefore does not reveal to any merchants that you might own bitcoins. For a full guide, check out the following article: [https://www.econoalchemist.com/post/backup](https://www.econoalchemist.com/post/backup){:target="_blank"} *(note: the jig is optional, no need to buy it if you don't have a 3D printer)*.
 
 * Exit the user "lnd" user session, and then exit the second SSH session altogether
 


### PR DESCRIPTION
#### What

This PR aims at adding an optional recommendation to not only backup the LND wallet 24 mnemonic words on paper but also on steel to have a much more resilient backup. In the DIY spirit of RaspiBolt, the recommendation is to use a DIY solution with off-the-shelf items only (no bitcoin merchants used) to reduce privacy/security risks (merchant client DB leaks etc): stamped steel washers held on a bolt.

### Why

In case of node failure, the 24 words / mnemonics are indispensible to initiate a SCB recovery and recover all the user funds onchain. These words could secure a significant amount of bitcoins and therefore a resilient storage method must be recommended. The solution proposed is very aligned with the RaspiBolt ethos.

#### How

Added an extra paragraph after the paper backup paragraph that explains the solution, rationales and point towards an external guide. Slightly modified the format of the paragraph to make the steel recommendation a level 2 list item vs the compulsory paper backup which is now a level 1 list item.

#### Scope

- [ ] significant change to core configuration
- [x] minor change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

No need for tests (this is a well-known and tested technique).
The only maintenance needed would be to occasionally check that the external link is not dead. If the link becomes dead, a bonus guide to be written instead to explain the method.

![washers](https://github.com/VajraOfIndra/RaspiBolt/blob/pics/images/washers_small.png?raw=true)

