### PR TITLE
Update lntop bonus guide for RaspiBolt v3

### DIFF
--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -28,12 +28,16 @@ Difficulty: Easy
 
 ### Install lntop
 
+* As user "admin", download and install application
+
 ```bash
-$ wget https://github.com/edouardparis/lntop/releases/download/v0.1.0/lntop_Linux_armv6.tar.gz
-$ tar -xzf lntop_Linux_armv6.tar.gz lntop
+$ cd /tmp/
+$ wget https://github.com/edouardparis/lntop/releases/download/v0.1.0/lntop_Linux_arm64.tar.gz
+$ tar -xzf lntop_Linux_arm64.tar.gz lntop
 $ sudo install -m 0755 -o root -g root -t /usr/local/bin lntop && rm lntop
-$ rm lntop_Linux_armv6.tar.gz
+$ rm lntop_Linux_arm64.tar.gz
 ```
+
 ### Run lntop
 
 ```bash


### PR DESCRIPTION
#### What

Fixes guide for RaspiBolt v3. Changes download from armv6 to arm64<del> and adds instructions about copying necessary LND credentials</del>.

#### Scope

- [ ] significant change to core configuration
- [X] independent bonus guide
- [X] simple bug fix

Note - there is also recent v0.2.0 release of lntop, but it does not provide precompiled binaries.