### PR TITLE
Fixed NodeJS version typo

### DIFF
--- a/rtl.md
+++ b/rtl.md
@@ -27,7 +27,7 @@ We install [Ride The Lightning](https://github.com/Ride-The-Lightning/RTL/blob/m
 ### Install NodeJS
 
 Starting with user “admin”, we switch to user “root” and add the Node JS package repository.
-We’ll use version 14 which is the most recent stable one.
+We’ll use version 14 which is well-tested with all web applications used in this guide.
 If you installed BTC RPC Explorer, then you've already accomplisehd this step.
 When finished, exit the “root” user session.
 

--- a/rtl.md
+++ b/rtl.md
@@ -27,7 +27,7 @@ We install [Ride The Lightning](https://github.com/Ride-The-Lightning/RTL/blob/m
 ### Install NodeJS
 
 Starting with user “admin”, we switch to user “root” and add the Node JS package repository.
-We’ll use version 12 which is the most recent stable one.
+We’ll use version 14 which is the most recent stable one.
 If you installed BTC RPC Explorer, then you've already accomplisehd this step.
 When finished, exit the “root” user session.
 


### PR DESCRIPTION
#### What

Fixes a small typo for the NodeJS version used for RTL.

### Why

To avoid confusion for new users.

#### How

Fixed typo "12" to "14"

#### Scope

- [ ] significant change to core configuration
- [x] minor change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

N/A

#### Additional remarks

NodeJS version 14 is describd as "the most recent stable one". However when checking [https://nodejs.org/en/about/releases/](https://nodejs.org/en/about/releases/) it shows v18 as "Current", v16 as the "Active LTS" and v14 and v12 as "Maintenance LTS". Wouldn't v16 be the most recent stable one? not sure how 'stable' matches the NodeJS terminology there! :)

Shoudl we reword "the most recent stable one"..?

![NodeJS](https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true)