### PR TITLE
Add passwords [D] & [E] for Explorer and RTL

### DIFF
--- a/btcrpcexplorer.md
+++ b/btcrpcexplorer.md
@@ -192,11 +192,11 @@ found 12 vulnerabilities (8 moderate, 4 high)
     ```
 
 * Optionally, you can add password protection to the web interface.
-  Simply add a password for the following option, for which the browser will then prompt you.
+  Simply add password [D] for the following option, for which the browser will then prompt you.
   You can enter any user name; only the password is checked.
 
   ```sh
-  BTCEXP_BASIC_AUTH_PASSWORD=AnyPassword
+  BTCEXP_BASIC_AUTH_PASSWORD=YourPassword[D]
   ```
 
 * Decide whether you prefer a `light` or `dark` theme

--- a/preparations.md
+++ b/preparations.md
@@ -56,6 +56,8 @@ They should be unique and very secure, at least 12 characters in length. Do **no
 [ A ] Master user password
 [ B ] Bitcoin RPC password
 [ C ] LND wallet password
+[ D ] BTC-RPC-Explorer (optional)
+[ E ] Ride The Lightning
 ```
 
 ![xkcd: Password Strength](images/preparations_xkcd.png)

--- a/preparations.md
+++ b/preparations.md
@@ -56,8 +56,8 @@ They should be unique and very secure, at least 12 characters in length. Do **no
 [ A ] Master user password
 [ B ] Bitcoin RPC password
 [ C ] LND wallet password
-[ D ] BTC-RPC-Explorer (optional)
-[ E ] Ride The Lightning
+[ D ] BTC-RPC-Explorer password (optional)
+[ E ] Ride The Lightning password
 ```
 
 ![xkcd: Password Strength](images/preparations_xkcd.png)

--- a/rtl.md
+++ b/rtl.md
@@ -154,11 +154,10 @@ Now we take the sample configuration file and add change it to our needs.
   nano RTL-Config.json
   ```
 
-* Set a password to access the RTL web interface.
-  This should be a dedicated password not used anywhere else.
+* Set password [E] to access the RTL web interface. This should be a dedicated password not used anywhere else.
 
   ```sh
-    "multiPass": "password"
+    "multiPass": "YourPassword[E]"
   ```
 
 * Specify the values where RTL can find the authentication macaroon file and the LND configuration


### PR DESCRIPTION
#### What

Passwords used at various steps of the guide are setup at the start in the 'Preparation' section and given a letter name (A to C for now). 

An optional password is discussed for the Explorer and a compulsory password is required for RTL. These two passwords are not mentionned yet in the preparation section.

For consistency, this PR proposes to add password [D] and [E] in the preparation section for respectively the Explorer and RTL. The PR also refers to passwords [D] and [E] in the Explorer and RTL guides (as is done for passwords A to C in the other guides that use them).

### Why

Improves guide consistency. Reduce the risk of users not recording the passwords for Epxlorer and RTL in a proper way.

#### How

Added references to passwords [D] and [E]

#### Scope

- [ ] significant change to core configuration
- [x] minor change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Test: just checking that the right password letters are used in the right section of the guides
Maintenance: None

![password](https://media4.giphy.com/media/MeOlWcfkXVS7nqDkow/giphy.webp?cid=ecf05e4755sf3lpsiqbpl5cy3lkmgfbbuy177kn9bf8931pe&rid=giphy.webp&ct=g)
