### PR TITLE
Recognize Markdown as language in repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Linguist overrides
+*.md linguist-detectable=true
+README.md linguist-detectable=false
+readme.md linguist-detectable=false


### PR DESCRIPTION
#### What

This PR allows Markdown to be counted in the repo language stats

### Why

To avoid possible confusion for new users about the content of the repo.

#### How

I followed the following [guide](https://joshuatz.com/posts/2019/how-to-get-github-to-recognize-a-pure-markdown-repo/).
The language stats is done by [linguist](https://github.com/github/linguist). Mardown files are ignored by default but this can be overide by adding a `.gitattributes` file in the root folder of the repo that contains a few options.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Test: Create file in root folder of local repo. Check that the language stats now contains Markdown and is > ~90%.
Maintenance: None

#### Animated GIF (optional)

![Add some snazz if you feel like it :)](https://media1.giphy.com/media/n8IDk4HoJJu18IqQIX/200w.webp?cid=ecf05e47uac86cq31x24mdw2jidb4tm4qk3dn6hkzx4hfn32&rid=200w.webp&ct=g)
