### PR TITLE
Tor: move web endpoints to TLS/SSL

### DIFF
--- a/btcrpcexplorer.md
+++ b/btcrpcexplorer.md
@@ -291,20 +291,22 @@ You can easily do so by adding a Tor hidden service on the RaspiBolt and accessi
 
   ```sh
   ############### This section is just for location-hidden services ###
-  HiddenServiceDir /var/lib/tor/hidden_service_btcrpcexplorer/
+  HiddenServiceDir /var/lib/tor/hidden_service_btcrpcexplorer_ssl/
   HiddenServiceVersion 3
-  HiddenServicePort 80 127.0.0.1:3002
+  HiddenServicePort 443 127.0.0.1:4000
   ```
 
 * Reload Tor configuration and get your connection address.
 
   ```sh
   $ sudo systemctl reload tor
-  $ sudo cat /var/lib/tor/hidden_service_btcrpcexplorer/hostname
+  $ sudo cat /var/lib/tor/hidden_service_btcrpcexplorer_ssl/hostname
   > abcdefg..............xyz.onion
   ```
 
 * With the [Tor browser](https://www.torproject.org){:target="_blank"}, you can access this onion address from any device.
+  You will get a warning in the browser, but that's expected due to our self-signed certificate.
+  Click on "Advanced..." and "Accept the Risk and Continue".
 
 **Congratulations!**
 You now have the BTC RPC Explorer running to check the Bitcoin network information directly from your node.

--- a/rtl.md
+++ b/rtl.md
@@ -247,20 +247,23 @@ You can easily add a Tor hidden service on the RaspiBolt and access the Ride the
 
   ```sh
   ############### This section is just for location-hidden services ###
-  HiddenServiceDir /var/lib/tor/hidden_service_rtl/
+  HiddenServiceDir /var/lib/tor/hidden_service_rtl_ssl/
   HiddenServiceVersion 3
-  HiddenServicePort 80 127.0.0.1:3000
+  HiddenServicePort 443 127.0.0.1:4001
   ```
 
   Update Tor configuration changes and get your connection address.
 
   ```sh
   $ sudo systemctl reload tor
-  $ sudo cat /var/lib/tor/hidden_service_rtl/hostname
+  $ sudo cat /var/lib/tor/hidden_service_rtl_ssl/hostname
   > abcefg...................zyz.onion
   ```
 
-With the Tor browser (link this), you can access this onion address from any device.
+* With the [Tor browser](https://www.torproject.org){:target="_blank"}, you can access this onion address from any device.
+  You will get a warning in the browser, but that's expected due to our self-signed certificate.
+  Click on "Advanced..." and "Accept the Risk and Continue".
+
 
 **Congratulations!**
 You now have Ride the Lightning running to manage your Lightning service on our own node.


### PR DESCRIPTION
#### What

Login passwords transmitted without TLS/SSL over the Tor network 
are a security risk if some of the nodes routing the traffic are
malicious.

### Why

While the Tor network is encrypted in itself, malicious actors can run
nodes that can snoop on traffic. A password transmitted in cleartext
could allow to log in to RTL and steal your Bitcoin (if no 2FA enabled).

### How

This change moves all web endpoint exposed as Tor .onion addresses
to the NGINX ports, adding TLS/SSL for additional encryption on top of
the Tor network.

The downside is that this will show a browser warning due to the
self-signed certificate.

### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

### Test & maintenance

Test this pull request by adding the new services and connecting with the Tor browser. No ongoing maintenance needed.

#### Animated GIF (optional)

![](https://media.giphy.com/media/115BJle6N2Av0A/giphy.gif)
