### PR TITLE
lntop: update to v0.2.0

### DIFF
--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -68,7 +68,7 @@ Table of contents
 * Verify the signed checksum against the actual checksum of your download
 
   ```sh
-  $ $ sha256sum --check checksums-lntop-v0.2.0.txt --ignore-missing
+  $ sha256sum --check checksums-lntop-v0.2.0.txt --ignore-missing
   > lntop-v0.2.0-Linux-arm64.tar.gz: OK
   ```
 
@@ -83,10 +83,12 @@ Table of contents
 
 ### Run lntop
 
-```bash
+Depending on the size of your LND channel database, lntop can take quite a while to start.
+
+```sh
 $ lntop
 ```
 
-------
+---
 
 << Back: [+ Lightning](index.md)

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -7,42 +7,86 @@ nav_exclude: true
 has_toc: false
 ---
 
-## Bonus guide: lntop: LNTOP terminal dashboard
+## Bonus guide: LNTOP terminal dashboard
 {: .no_toc }
+
+---
+
+[lntop](https://github.com/edouardparis/lntop){:target="_blank"} is an interactive text-mode channels viewer for Unix systems.
 
 Difficulty: Easy
 {: .label .label-green }
 
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
-
-[lntop](https://github.com/edouardparis/lntop) is an interactive text-mode channels viewer for Unix systems.
+Status: Tested v3
+{: .label .label-green }
 
 ![lntop](../../images/74_lntop.png)
 
+---
+
+Table of contents
+{: .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
 ### Install lntop
 
-* As user "admin", download and install application
+* As user “admin”, download the application, checksums, and the corresponding signature file
 
-```bash
-$ cd /tmp/
-$ wget https://github.com/edouardparis/lntop/releases/download/v0.1.0/lntop_Linux_arm64.tar.gz
-$ tar -xzf lntop_Linux_arm64.tar.gz lntop
-$ sudo install -m 0755 -o root -g root -t /usr/local/bin lntop && rm lntop
-$ rm lntop_Linux_arm64.tar.gz
-```
+  ```sh
+  $ cd /tmp/
+  $ wget https://github.com/edouardparis/lntop/releases/download/v0.2.0/lntop-v0.2.0-Linux-arm64.tar.gz
+  $ wget https://github.com/edouardparis/lntop/releases/download/v0.2.0/checksums-lntop-v0.2.0.txt
+  $ wget https://github.com/edouardparis/lntop/releases/download/v0.2.0/checksums-lntop-v0.2.0.txt.sig
+  ```
+
+* Get the PGP key from Edouard, developer of lntop.
+  You can compare the fingerprint against the one in his [Twitter profile](https://twitter.com/edouardparis){:target="_blank"}
+
+  ```sh
+  $ curl https://edouard.paris/key.asc | gpg --import
+  > ...
+  > gpg: key 47EEBB014DD80918: public key "Edouard (Personal) <m@edouard.paris>" imported
+  > ...
+  ```
+
+* Verify the signature of the text file containing the checksums for the application
+
+  ```sh
+  $ gpg --verify checksums-lntop-v0.2.0.txt.sig checksums-lntop-v0.2.0.txt
+  > gpg: Signature made Fri Dec  3 09:29:24 2021 GMT
+  > gpg:                using RSA key A8BA5205BFCBC668853D560247EEBB014DD80918
+  > gpg: Good signature from "Edouard (Personal) <m@edouard.paris>" [unknown]
+  > gpg: WARNING: This key is not certified with a trusted signature!
+  > gpg:          There is no indication that the signature belongs to the owner.
+  > Primary key fingerprint: A8BA 5205 BFCB C668 853D  5602 47EE BB01 4DD8 0918
+  ```
+
+* Verify the signed checksum against the actual checksum of your download
+
+  ```sh
+  $ $ sha256sum --check checksums-lntop-v0.2.0.txt --ignore-missing
+  > lntop-v0.2.0-Linux-arm64.tar.gz: OK
+  ```
+
+* If everything checks out, you can install the application
+
+  ```sh
+  $ tar -xvf lntop-v0.2.0-Linux-arm64.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin release/lntop
+  ```
+
+---
 
 ### Run lntop
 
 ```bash
 $ lntop
 ```
+
 ------
 
 << Back: [+ Lightning](index.md)


### PR DESCRIPTION
#### What

Update to latest release now that binaries are available.

### Why

Version 0.2.0 of lntop adds some new features and bugfixes:  
https://github.com/edouardparis/lntop/releases/tag/v0.2.0

This change also adds binary signature verification as best practice.

### How

Simple update of download links, plus added instructions for checksum signature validation. See https://github.com/edouardparis/lntop/issues/49 for some context.

Deleting downloaded files is removed as these are small and the /tmp folder is purged on every reboot anyway.

### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple application update

### Test & maintenance

Follow instructions and run `lntop`