### PR TITLE
Fix: Bonus guide link

### DIFF
--- a/index.md
+++ b/index.md
@@ -72,7 +72,7 @@ The bonus section contains more specific guides that build on top of the main se
 More fun, lots of knowledge, but with lesser maintenance guarantees.
 Everything is optional.
 
-- [Bonus guides](./bonus/index.md)
+* [Bonus guides](./bonus/index.md)
 
 Running into issues?
 

--- a/index.md
+++ b/index.md
@@ -72,7 +72,7 @@ The bonus section contains more specific guides that build on top of the main se
 More fun, lots of knowledge, but with lesser maintenance guarantees.
 Everything is optional.
 
-* [Bonus guides](bonus-section.md)
+- [Bonus guides](./bonus/index.md)
 
 Running into issues?
 


### PR DESCRIPTION
#### What

A tiny little link fix :-) 

### Why

https://raspibolt.org/bonus-section.md seems to be dead

#### How

Replacing the link and testing it through:

> `docker run --rm -it -v $(pwd):/srv/jekyll -p 4000:4000 jekyll/jekyll:pages jekyll serve --watch`

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

P.S: Pretty cool how the project evolved from simple markdown files, props for the work 👍 