### PR TITLE
minor fixes: Electrs, RTL, BTC RPC Explorer

### DIFF
--- a/btcrpcexplorer.md
+++ b/btcrpcexplorer.md
@@ -71,9 +71,9 @@ You can follow the progress using `tail -f ~/.bitcoin/debug.log`.
 ### Firewall & reverse proxy
 
 In the [Security section](security.md), we set up NGINX as a reverse proxy.
-Now we can add the RTL configuration.
+Now we can add the BTC RPC Explorer configuration.
 
-* Enable NGINX reverse proxy to route external encrypted HTTPS traffic internally to RTL
+* Enable NGINX reverse proxy to route external encrypted HTTPS traffic internally to the BTC RPC Explorer
 
   ```sh
   $ sudo nano /etc/nginx/streams-enabled/btcrpcexplorer-reverse-proxy.conf
@@ -311,7 +311,7 @@ You now have the BTC RPC Explorer running to check the Bitcoin network informati
 
 ---
 
-## Upgrade
+## For the future: BTC RPC Explorer update
 
 Updating to a [new release](https://github.com/janoside/btc-rpc-explorer/releases){:target="_blank"} is straight-forward, but make sure to check out the [change log](https://github.com/janoside/btc-rpc-explorer/blob/master/CHANGELOG.md){:target="_blank"} first.
 
@@ -327,7 +327,7 @@ Updating to a [new release](https://github.com/janoside/btc-rpc-explorer/release
   ```sh
   $ cd /home/btcrpcexplorer/btc-rpc-explorer
   $ git fetch
-  $ git describe --tags
+  $ git describe --tags --abbrev=0
   $ git checkout v3.2.0
   $ npm install
   $ exit

--- a/electrs.md
+++ b/electrs.md
@@ -434,7 +434,7 @@ Make sure to check the [release notes](https://github.com/romanz/electrs/blob/ma
 
   # update the local source code and show the latest release tag (example: v9.9.9)
   $ git fetch
-  $ git describe --tags
+  $ git describe --tags --abbrev=0
   > v9.9.9
 
   # check out the most recent release (replace v9.9.9 with the actual version)

--- a/rtl.md
+++ b/rtl.md
@@ -103,7 +103,7 @@ We do not want to run Ride the Lightning alongside bitcoind and lnd because of s
   $ git clone https://github.com/Ride-The-Lightning/RTL.git
   $ cd RTL
 
-  $ git describe --tags
+  $ git describe --tags --abbrev=0
   > v0.11.2
 
   $ git checkout v0.11.2
@@ -273,11 +273,12 @@ If you want to be extra careful, you can enable 2FA for access to your RTL inter
 * Select the "Authentication" tab and click on the "Enable 2FA" button
 * Follow the instructions, using a 2FA app like Google Authenticator or Authy
 
-## Upgrading
+## For the future: RTL upgrade
 
-Updating to a [new release](https://github.com/janoside/btc-rpc-explorer/releases){:target="_blank"} is straight-forward, but make sure to check out the [change log](https://github.com/janoside/btc-rpc-explorer/blob/master/CHANGELOG.md){:target="_blank"} first.
+Updating to a [new release](https://github.com/Ride-The-Lightning/RTL/releases){:target="_blank"} is straight-forward.
+Make sure to read the release notes first.
 
-* From user "admin", stop the service and open a "btcrpcexplorer" user session.
+* From user "admin", stop the service and open a "rtl" user session.
 
   ```sh
   $ sudo systemctl stop rtl
@@ -289,7 +290,7 @@ Updating to a [new release](https://github.com/janoside/btc-rpc-explorer/release
   ```sh
   $ cd /home/rtl/RTL
   $ git fetch
-  $ git describe --tags
+  $ git describe --tags --abbrev=0
   $ git checkout v9.99.9
   $ git verify-tag v9.99.9
   $ npm install --only=prod


### PR DESCRIPTION
#### What

This change fixes a few minor errors in for Electrs, RTL, and BTC RPC Explorer:

* copy/paste errors in NGINX config
* wrong link to upgrade repository
* use 'git describe --tags --abbrev=0' to get the most current tag (see [documentation](https://git-scm.com/docs/git-describe#Documentation/git-describe.txt---abbrevltngt))

#### Why

Consitency and accuracy

#### How

Just some wording changes

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

wording only, might run `git describe` command
