### PR TITLE
Add section on how to use lntop

### DIFF
--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -106,8 +106,8 @@ To use all the functionalities of lntop, use the following keys:
   3) Press F2 to enter the desired view and exit the left Menu bar
      
 * **← (or h), → (or l), ↑ (or j), ↓ (or k)** = 
-  * (when the left Menu bar is active) = Navigate the Menu options (up and down only)
-  * (when the left Menu bar is inactive) = Navigate the colmuns and/or lines of the displayed table (CHANNEL, TRANSAC or ROUTING)
+  * *when the left Menu bar is active* = Navigate the Menu options (up and down only)
+  * *when the left Menu bar is inactive* = Navigate the colmuns and/or lines of the displayed table (CHANNEL, TRANSAC or ROUTING)
 
 * **Enter** = 
   * *when the left Menu bar is active*: See the content of the desired Menu entry

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -110,8 +110,8 @@ To use all the functionalities of lntop, use the following keys:
   * (when the left Menu bar is inactive) = Navigate the colmuns and/or lines of the displayed table (CHANNEL, TRANSAC or ROUTING)
 
 * **Enter** = 
-  * (when the left Menu bar is active) = See the content of the desired Menu entry
-  * (when the left Meny bar is inactive) = Displays additional information on a channel or transaction, depending on the table being viewed:
+  * *when the left Menu bar is active*: See the content of the desired Menu entry
+  * *when the left Meny bar is inactive*: Displays additional information on a channel or transaction, depending on the table being viewed:
     * CHANNEL = Display detailed information about a channel
     * TRANSAC = Display detailed information about a transaction
     * ROUTING = Display detailed information about a forwarded payment

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -111,7 +111,7 @@ To use all the functionalities of lntop, use the following keys:
 
 * **Enter** = 
   * *when the left Menu bar is active*: See the content of the desired Menu entry
-  * *when the left Meny bar is inactive*: Displays additional information on a channel or transaction, depending on the table being viewed:
+  * *when the left Menu bar is inactive*: Displays additional information on a channel or transaction, depending on the table being viewed:
     * CHANNEL = Display detailed information about a channel
     * TRANSAC = Display detailed information about a transaction
     * ROUTING = Display detailed information about a forwarded payment

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -97,13 +97,13 @@ $ lntop
   
   * **F1 (or h)** = Display an "About" page and a list of keyboard keys to use (press F1 again to exit this screen)
   
-  * **F2 (or m)** = Display a Menu bar on the left, there are three table options:
-    * 1) Navigate the Menu with the up and down keys (see below); there are three options:  
+  * **F2 (or m)** = Display a Menu bar on the left
+    1) Navigate the Menu with the up and down keys (see below); there are three options:  
       *  CHANNEL = (the home page/default view), a table of all channels
       *  TRANSAC = a table of lightning transactions
       *  ROUTING = a table of routing event as they happen (no historical events shown, and any displayed event will be deleted if you leave this view)
-    * 2) Press Enter to see the desired view
-    * 3) Press F2 to enter the desired view and exit the left Menu bar
+    2) Press Enter to see the desired view
+    3) Press F2 to enter the desired view and exit the left Menu bar
      
   * **←, →, ↑, ↓** (i.e. left, right, down and up arrows) = 
     * (when the left menu bqr is active) = Navigate the Menu options (up and down only)

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -105,9 +105,13 @@ To use all the functionalities of lntop, use the following keys:
   2) Press Enter to see the desired view
   3) Press F2 to enter the desired view and exit the left Menu bar
      
-* **← (or h), → (or l), ↑ (or j), ↓ (or k)** = 
+* **←, →, ↑, ↓** = 
   * *when the left Menu bar is active* = Navigate the Menu options (up and down only)
-  * *when the left Menu bar is inactive* = Navigate the colmuns and/or lines of the displayed table (CHANNEL, TRANSAC or ROUTING)
+  * *when the left Menu bar is inactive* = Navigate the colmuns (left, right) and/or the lines (up, down) of the displayed table (CHANNEL, TRANSAC or ROUTING)
+
+* **Home** = Navigate to the first line of the table
+
+* **End** = Navigate to the last line of the table
 
 * **Enter** = 
   * *when the left Menu bar is active*: See the content of the desired Menu entry

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -105,7 +105,7 @@ To use all the functionalities of lntop, use the following keys:
   2) Press Enter to see the desired view
   3) Press F2 to enter the desired view and exit the left Menu bar
      
-* **← (or h), → (or l), ↑ (or j), ↓ (or k)** (i.e. left, right, down and up arrows) = 
+* **← (or h), → (or l), ↑ (or j), ↓ (or k)** = 
   * (when the left Menu bar is active) = Navigate the Menu options (up and down only)
   * (when the left Menu bar is inactive) = Navigate the colmuns and/or lines of the displayed table (CHANNEL, TRANSAC or ROUTING)
 

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -91,4 +91,16 @@ $ lntop
 
 ---
 
+### lntop in action
+
+* Use the following keys:
+  
+  * F1 = Display a menu with a list if useful keys
+  * F2 or m = Menu
+  * ←, →, ↑, ↓ (left, right, down and up arrows) = Navigate the lines and columns
+  * h, l, j, k = Navigate the lines and columns
+  * q or F10 or Ctrl+C = Quit lntop
+  * a = Sort out column, ascending order
+  * d = SOrt out colmun, descending order
+
 << Back: [+ Lightning](index.md)

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -94,18 +94,18 @@ $ lntop
 ### lntop in action
 
 To use all the functionalities of lntop, use the following keys:
-  
+
 * **F1 (or h)** = Display an "About" page and a list of keyboard keys to use (press F1 again to exit this screen)
-  
+
 * **F2 (or m)** = Display a Menu bar on the left
-  1) Navigate the Menu with the up and down keys (see below); there are three options:  
+  1. Navigate the Menu with the up and down keys (see below); there are three options:
     *  CHANNEL = (the home page/default view), a table of all channels
     *  TRANSAC = a table of lightning transactions
     *  ROUTING = a table of routing event as they happen (no historical events shown, and any displayed event will be deleted if you quit lntop)
-  2) Press Enter to see the desired view
-  3) Press F2 to enter the desired view and exit the left Menu bar
-     
-* **←, →, ↑, ↓** = 
+  1. Press Enter to see the desired view
+  1. Press F2 to enter the desired view and exit the left Menu bar
+
+* **Arrow keys: ←, →, ↑, ↓** =
   * *when the left Menu bar is active* = Navigate the Menu options (up and down only)
   * *when the left Menu bar is inactive* = Navigate the colmuns (left, right) and/or the lines (up, down) of the displayed table (CHANNEL, TRANSAC or ROUTING)
 
@@ -113,17 +113,21 @@ To use all the functionalities of lntop, use the following keys:
 
 * **End** = Navigate to the last line of the table
 
-* **Enter** = 
+* **Enter** =
   * *when the left Menu bar is active*: See the content of the desired Menu entry
   * *when the left Menu bar is inactive*: Displays additional information on a channel or transaction, depending on the table being viewed:
     * CHANNEL = Display detailed information about a channel
     * TRANSAC = Display detailed information about a transaction
     * ROUTING = Display detailed information about a forwarded payment
- 
+
 * **a** = Sort out column, ascending order
- 
+
 * **d** = Sort out column, descending order
 
 * **F10 (or q or Ctrl+C)** = Quit lntop
+
+<br /><br />
+
+---
 
 << Back: [+ Lightning](index.md)

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -95,9 +95,9 @@ $ lntop
 
 * To use all the functionalities of lntop, use the following keys:
   
-  * F1 or h = Display an "About" page and a list of keyboard keys to use (press F1 again to exit this screen)
+  * **F1 (or h)** = Display an "About" page and a list of keyboard keys to use (press F1 again to exit this screen)
   
-  * F2 (or m) = Display a Menu bar on the left, there are three table options:
+  * **F2 (or m)** = Display a Menu bar on the left, there are three table options:
     * 1) Navigate the Menu with the up and down keys (see below); there are three options:  
       *  CHANNEL = (the home page/default view), a table of all channels
       *  TRANSAC = a table of lightning transactions
@@ -105,23 +105,23 @@ $ lntop
     * 2) Press Enter to see the desired view
     * 3) Press F2 to enter the desired view and exit the left Menu bar
      
-  * ←, →, ↑, ↓ (i.e. left, right, down and up arrows) = 
+  * **←, →, ↑, ↓** (i.e. left, right, down and up arrows) = 
     * (when the left menu bqr is active) = Navigate the Menu options (up and down only)
     * (when the left Menu bar is inactive) = Navigate the colmuns and/or lines of the displayed table (CHANNEL, TRANSAC or ROUTING)
   
-  * h, l, j, k = 1) Navigate the Menu options; 2) Navigate the colmuns/lines of the tables
+  * **h, l, j, k** = 1) Navigate the Menu options; 2) Navigate the colmuns/lines of the tables
 
-  * Enter = 
+  * **Enter** = 
     * (when the left Menu bar is active) = See the content of the desired Menu entry
     * (when the left Meny bar is inactive) = Displays additional information on a channel or transaction, depending on the table being viewed:
       * CHANNEL = Display detailed information about a channel
       * TRANSAC = Display detailed information about a transaction
       * ROUTING = Display detailed information about a forwarded payment
  
-  * a = Sort out column, ascending order
+  * **a** = Sort out column, ascending order
   
-  * d = Sort out colmun, descending order
+  * **d** = Sort out colmun, descending order
 
-  * F10 or q or Ctrl+C = Quit lntop
+  * **F10 (or q or Ctrl+C)** = Quit lntop
 
 << Back: [+ Lightning](index.md)

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -93,35 +93,33 @@ $ lntop
 
 ### lntop in action
 
-* To use all the functionalities of lntop, use the following keys:
+To use all the functionalities of lntop, use the following keys:
   
-  * **F1 (or h)** = Display an "About" page and a list of keyboard keys to use (press F1 again to exit this screen)
+* **F1 (or h)** = Display an "About" page and a list of keyboard keys to use (press F1 again to exit this screen)
   
-  * **F2 (or m)** = Display a Menu bar on the left
-    1) Navigate the Menu with the up and down keys (see below); there are three options:  
-      *  CHANNEL = (the home page/default view), a table of all channels
-      *  TRANSAC = a table of lightning transactions
-      *  ROUTING = a table of routing event as they happen (no historical events shown, and any displayed event will be deleted if you leave this view)
-    2) Press Enter to see the desired view
-    3) Press F2 to enter the desired view and exit the left Menu bar
+* **F2 (or m)** = Display a Menu bar on the left
+  1) Navigate the Menu with the up and down keys (see below); there are three options:  
+    *  CHANNEL = (the home page/default view), a table of all channels
+    *  TRANSAC = a table of lightning transactions
+    *  ROUTING = a table of routing event as they happen (no historical events shown, and any displayed event will be deleted if you quit lntop)
+  2) Press Enter to see the desired view
+  3) Press F2 to enter the desired view and exit the left Menu bar
      
-  * **←, →, ↑, ↓** (i.e. left, right, down and up arrows) = 
-    * (when the left menu bqr is active) = Navigate the Menu options (up and down only)
-    * (when the left Menu bar is inactive) = Navigate the colmuns and/or lines of the displayed table (CHANNEL, TRANSAC or ROUTING)
-  
-  * **h, l, j, k** = 1) Navigate the Menu options; 2) Navigate the colmuns/lines of the tables
+* **← (or h), → (or l), ↑ (or j), ↓ (or k)** (i.e. left, right, down and up arrows) = 
+  * (when the left Menu bar is active) = Navigate the Menu options (up and down only)
+  * (when the left Menu bar is inactive) = Navigate the colmuns and/or lines of the displayed table (CHANNEL, TRANSAC or ROUTING)
 
-  * **Enter** = 
-    * (when the left Menu bar is active) = See the content of the desired Menu entry
-    * (when the left Meny bar is inactive) = Displays additional information on a channel or transaction, depending on the table being viewed:
-      * CHANNEL = Display detailed information about a channel
-      * TRANSAC = Display detailed information about a transaction
-      * ROUTING = Display detailed information about a forwarded payment
+* **Enter** = 
+  * (when the left Menu bar is active) = See the content of the desired Menu entry
+  * (when the left Meny bar is inactive) = Displays additional information on a channel or transaction, depending on the table being viewed:
+    * CHANNEL = Display detailed information about a channel
+    * TRANSAC = Display detailed information about a transaction
+    * ROUTING = Display detailed information about a forwarded payment
  
-  * **a** = Sort out column, ascending order
-  
-  * **d** = Sort out colmun, descending order
+* **a** = Sort out column, ascending order
+ 
+* **d** = Sort out colmun, descending order
 
-  * **F10 (or q or Ctrl+C)** = Quit lntop
+* **F10 (or q or Ctrl+C)** = Quit lntop
 
 << Back: [+ Lightning](index.md)

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -122,7 +122,7 @@ To use all the functionalities of lntop, use the following keys:
  
 * **a** = Sort out column, ascending order
  
-* **d** = Sort out colmun, descending order
+* **d** = Sort out column, descending order
 
 * **F10 (or q or Ctrl+C)** = Quit lntop
 

--- a/bonus/lightning/lntop.md
+++ b/bonus/lightning/lntop.md
@@ -93,14 +93,35 @@ $ lntop
 
 ### lntop in action
 
-* Use the following keys:
+* To use all the functionalities of lntop, use the following keys:
   
-  * F1 = Display a menu with a list if useful keys
-  * F2 or m = Menu
-  * ←, →, ↑, ↓ (left, right, down and up arrows) = Navigate the lines and columns
-  * h, l, j, k = Navigate the lines and columns
-  * q or F10 or Ctrl+C = Quit lntop
+  * F1 or h = Display an "About" page and a list of keyboard keys to use (press F1 again to exit this screen)
+  
+  * F2 (or m) = Display a Menu bar on the left, there are three table options:
+    * 1) Navigate the Menu with the up and down keys (see below); there are three options:  
+      *  CHANNEL = (the home page/default view), a table of all channels
+      *  TRANSAC = a table of lightning transactions
+      *  ROUTING = a table of routing event as they happen (no historical events shown, and any displayed event will be deleted if you leave this view)
+    * 2) Press Enter to see the desired view
+    * 3) Press F2 to enter the desired view and exit the left Menu bar
+     
+  * ←, →, ↑, ↓ (i.e. left, right, down and up arrows) = 
+    * (when the left menu bqr is active) = Navigate the Menu options (up and down only)
+    * (when the left Menu bar is inactive) = Navigate the colmuns and/or lines of the displayed table (CHANNEL, TRANSAC or ROUTING)
+  
+  * h, l, j, k = 1) Navigate the Menu options; 2) Navigate the colmuns/lines of the tables
+
+  * Enter = 
+    * (when the left Menu bar is active) = See the content of the desired Menu entry
+    * (when the left Meny bar is inactive) = Displays additional information on a channel or transaction, depending on the table being viewed:
+      * CHANNEL = Display detailed information about a channel
+      * TRANSAC = Display detailed information about a transaction
+      * ROUTING = Display detailed information about a forwarded payment
+ 
   * a = Sort out column, ascending order
-  * d = SOrt out colmun, descending order
+  
+  * d = Sort out colmun, descending order
+
+  * F10 or q or Ctrl+C = Quit lntop
 
 << Back: [+ Lightning](index.md)


### PR DESCRIPTION
#### What

This PR adds a section to the lntop bonus guide that explains how to use it (what keys to use and how to navigate the displays).

### Why

The navigation is not necessarily easy to work out and the explanations are a bit hard to find! Laying out clear instructions would help users to make the most of lntop :)

#### How

Used the 'keybindings.go' file from the lntop repo ([link](https://github.com/edouardparis/lntop/blob/650f1420d35b16f97f52dc828f8c9a095bc6a7c9/ui/keybindings.go)) to work out what keys are used for what purpose.

Added a section to the guide listing all the keys and what they do.

#### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Test:
* Install lntop
* Go through the explanations and try out each key and see if result is as described

Maintenance: Occasional updates when/if the lntop developper add or changes the keys

#### Animated GIF (optional)

![keyboard](https://media.giphy.com/media/w6TfGhqQCvk7m/giphy.gif)