### PR TITLE
github-actions: warn and auto-close issues & prs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '31 * * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 60
+        days-before-issue-close: 7
+        stale-issue-message: 'This issue is marked as `stale` because there was no activity for 60 days. If the issue stays inactive, it will be closed in a week.'
+        stale-issue-label: 'stale'
+        close-issue-message: 'This issue has been closed due to inactivity.'
+
+        days-before-pr-stale: 90
+        days-before-pr-close: 30
+        stale-pr-message: 'This pull request is marked as `stale` because there was no activity for 90 days. If the pull request stays inactive, it will be closed automatically in 90 days.'
+        stale-pr-label: 'stale'
+        close-pr-message: 'This pull request has been closed due to inactivity.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,6 +29,6 @@ jobs:
 
         days-before-pr-stale: 90
         days-before-pr-close: 30
-        stale-pr-message: 'This pull request is marked as `stale` because there was no activity for 90 days. If the pull request stays inactive, it will be closed automatically in 90 days.'
+        stale-pr-message: 'This pull request is marked as `stale` because there was no activity for 90 days. If the pull request stays inactive, it will be closed automatically in 30 days.'
         stale-pr-label: 'stale'
         close-pr-message: 'This pull request has been closed due to inactivity.'


### PR DESCRIPTION
### What

Monitor the activity of GitHub issues and pull requests, mark them as stale after a period of inactivity, and automatically close them if no activity occurs after.

**The specific timing and wording when closing items are open for debate, feedback is welcome!**

### Why

Support is given on a best-effort basis. In my experience, issues quickly become irrelevant, and even if help is finally provided
with some delay, the original author usually no longer comes back. The same goes for pull requests that don't gain any traction. They become outdated, although on a longer time scale.

To keep open issues and pull requests relevant, it's good practice to close stale ones. This change proposes to mark issues as stale after 60 days of inactivity, and close them one week after, if no activity occurs. Pull requests are marked as stale after 90 days without any interaction, and automatically closed 30 days later in case of inactivity.

### How

GitHub actions provide a bot that does this automatically, giving a warning first (marking the item as 'stale'), and then automatically closing it later.

### Testing

This bot is currently running on https://github.com/Stadicus/raspibolt-dev, configured

* Configuration: https://github.com/Stadicus/raspibolt-dev/blob/master/.github/workflows/stale.yml
* Example issue: https://github.com/Stadicus/raspibolt-dev/issues/4
* Example pull request: https://github.com/Stadicus/raspibolt-dev/pull/5

#### Animated GIF (optional)

![](https://media.giphy.com/media/xT8qBvH1pAhtfSx52U/giphy.gif)
