### PR TITLE
Add testnet bonus page

### DIFF
--- a/guide/bonus/bitcoin/index.md
+++ b/guide/bonus/bitcoin/index.md
@@ -39,7 +39,7 @@ has_toc: false
 
 ## Testnet
 
-* **[Running a Testnet Raspibolt Node](testnet.md)** - configure your RaspiBolt for use on testnet
+* **[Running a Testnet RaspiBolt Node](testnet.md)** - configure your RaspiBolt for use on testnet
 
 ---
 

--- a/guide/bonus/bitcoin/index.md
+++ b/guide/bonus/bitcoin/index.md
@@ -37,4 +37,10 @@ has_toc: false
 
 ---
 
+## Testnet
+
+* **[Running a Testnet Raspibolt Node](testnet.md)** - configure your RaspiBolt for use on testnet
+
+---
+
 << Back: [Bonus Section](../index.md)

--- a/guide/bonus/bitcoin/testnet.md
+++ b/guide/bonus/bitcoin/testnet.md
@@ -120,7 +120,7 @@ Check the logs using
 $ sudo journalctl -u electrs -f
 ```
 
-## NGINX
+### NGINX
 File location: `/etc/nginx/streams-enabled/electrs-testnet-reverse-proxy.conf`
 ```ini
 upstream electrs {
@@ -140,7 +140,7 @@ $ sudo systemctl reload nginx
 $ sudo ufw allow 60002/tcp comment 'allow Electrum SSL Testnet'
 ```
 
-## Tor
+### Tor
 Create a separate service for testnet over Tor:
 
 File location: `/etc/tor/torrc`
@@ -157,7 +157,7 @@ $ sudo systemctl reload tor
 $ sudo cat /var/lib/tor/hidden_service_electrs_testnet/hostname
 ```
 
-## LDN
+## LND
 File location: `/data/lnd/lnd.conf`
 ```ini
 bitcoin.active=1

--- a/guide/bonus/bitcoin/testnet.md
+++ b/guide/bonus/bitcoin/testnet.md
@@ -1,0 +1,141 @@
+---
+layout: default
+title: RaspiBolt on Testnet
+parent: + Bitcoin
+grand_parent: Bonus Section
+nav_exclude: true
+has_children: false
+has_toc: false
+---
+
+# Bonus guide: RaspiBolt on Testnet
+{: .no_toc }
+
+Difficulty: Medium
+{: .label .label-yellow }
+
+Status: Tested v3
+{: .label .label-green }
+
+---
+
+Table of contents
+{: .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Introduction
+Running a testnet node is a great way to get acquainted with the RaspiBolt and the suite of Bitcoin-related software typical of these powerful setups. Moreover, testnet empowers users to tinker with the software and its many configurations without the threat of losing funds. Helping bitcoiners run a full testnet setup is a goal worthy of the RaspiBolt, and this page should provide you with the knowledge to get there.
+
+The great news is that most of the RaspiBolt guide can be used as-is. The small adjustments come in the form of changes to the config files and ports for testnet. You can follow the guide and simply replace the following configurations in the right places as you go.
+
+## Bitcoin daemon
+File location: `/data/bitcoin/bitcoin.conf`
+```ini
+# RaspiBolt: bitcoind configuration for testnet node
+
+# [chain]
+# main, test, signet, regtest
+chain=test
+
+# [core]
+sysperms=1
+blocksonly=1
+txindex=1
+# disable dbcache after full sync
+dbcache=2000
+
+# [wallet]
+disablewallet=1
+
+# [network]
+listen=1
+listenonion=1
+proxy=127.0.0.1:9050
+maxconnections=40
+maxuploadtarget=5000
+whitelist=download@127.0.0.1          # for Electrs
+
+# [rpc]
+rpcauth=your_string_from_the_rpcauth_script
+server=1
+
+# [zeromq]
+zmqpubrawblock=tcp://127.0.0.1:28332
+zmqpubrawtx=tcp://127.0.0.1:28333
+
+# Options specific to chain, rpcport set to default values
+[main]
+# rpcport=8332
+bind=127.0.0.1
+rpcbind=127.0.0.1
+
+[test]
+rpcport=18332
+bind=127.0.0.1
+rpcbind=127.0.0.1
+
+[signet]
+# rpcport=38332
+
+[regtest]
+# rpcport=18443
+```
+
+## Electrs
+File location: `/data/electrs/electrs.conf`
+```ini
+# RaspiBolt: electrs configuration for testnet node
+# /data/electrs/electrs.conf
+
+# Bitcoin Core settings
+network = "testnet"
+daemon_dir= "/home/bitcoin/.bitcoin/"
+daemon_rpc_addr = "127.0.0.1:18332"
+daemon_p2p_addr = "127.0.0.1:18333"
+cookie_file = "/data/bitcoin/testnet3/.cookie
+
+# Electrs settings
+electrum_rpc_addr = "127.0.0.1:60001"
+db_dir = "/data/electrs/db/"
+index_lookup_limit = 1000
+
+# Logging
+log_filters = "INFO"
+timestamp = true
+```
+
+## NGINX
+File location: `/etc/nginx/streams-enabled/electrs-testnet-reverse-proxy.conf`
+```ini
+upstream electrs {
+  server 127.0.0.1:60001;
+}
+
+server {
+  listen 60002 ssl;
+  proxy_pass electrs;
+}
+```
+
+## Tor
+File location: `/etc/tor/torrc`
+```ini
+############### This section is just for location-hidden services ###
+HiddenServiceDir /var/lib/tor/hidden_service_electrs/
+HiddenServiceVersion 3
+HiddenServicePort 60002 127.0.0.1:60002
+```
+
+## Interacting with the LND daemon
+Note that when interacting with the LND daemon, you'll need to use the `--network testnet` option like so:
+```sh
+lncli --network testnet walletbalance
+```
+
+---
+
+<< Back: [+ Bitcoin](index.md)

--- a/guide/bonus/bitcoin/testnet.md
+++ b/guide/bonus/bitcoin/testnet.md
@@ -11,6 +11,8 @@ has_toc: false
 # Bonus guide: RaspiBolt on Testnet
 {: .no_toc }
 
+You can run your RaspiBolt node on testnet to develop and experiment with new applications, without putting real money at risk. This bonus guide highlights all configuration changes compared to the main guide.
+
 Difficulty: Medium
 {: .label .label-yellow }
 
@@ -141,7 +143,7 @@ $ sudo ufw allow 60002/tcp comment 'allow Electrum SSL Testnet'
 ```
 
 ### Tor
-Create a separate service for testnet over Tor:
+Create a separate service for testnet over Tor by adding the following lines in the `location-hidden services` section:
 
 File location: `/etc/tor/torrc`
 ```ini
@@ -158,10 +160,15 @@ $ sudo cat /var/lib/tor/hidden_service_electrs_testnet/hostname
 ```
 
 ## LND
+The following are the lines that need changing in the LND configuration file.
+
 File location: `/data/lnd/lnd.conf`
 ```ini
+[Bitcoin]
 bitcoin.active=1
-# bitcoin.mainnet=1
+#bitcoin.mainnet=1
+bitcoin.testnet=1
+bitcoin.node=bitcoind
 ```
 
 And the following command gives members of the group `lnd` permission to traverse the LND directories to reach the macaroons:


### PR DESCRIPTION
## What
This draft PR adds a _Raspibolt on Testnet_ bonus guide page.

This PR is currently in draft mode because I'm still working on the Lightning part of the RaspiBolt guide, and so I expect more sections will be added before I'm through.

[See the in-progress page here](https://thunderbiscuit.github.io/raspibolt/bonus/bitcoin/testnet.html).

## Why
Testnet is awesome, and to quote the page: _Helping bitcoiners run a full testnet setup is a goal worthy of the RaspiBolt._

## Scope
- [x] independent bonus guide