### PR TITLE
Add 'Not tested v3' labels to untested legacy bonus guides + introducing labels in 'Bonus Section'  index page

### DIFF
--- a/bonus/bitcoin/electrum-personal-server.md.md
+++ b/bonus/bitcoin/electrum-personal-server.md.md
@@ -14,6 +14,9 @@ has_toc: false
 Difficulty: Intermediate
 {: .label .label-yellow }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/bitcoin/specter-desktop.md
+++ b/bonus/bitcoin/specter-desktop.md
@@ -14,6 +14,9 @@ has_toc: false
 Difficulty: Intermediate
 {: .label .label-yellow }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/index.md
+++ b/bonus/index.md
@@ -10,43 +10,38 @@ has_toc: false
 # Bonus Section
 {: .no_toc }
 
-In this section, you can find various optional topics that make your RaspiBolt running even smoother. I split this up in various subsections, as the individual tasks can be quite long.
-
-🚨 This section is not maintained as frequently and not tested as thoroughly as the main part of the guide. To use with caution!
+In the following categories, you can find various additional and optional guides that make your RaspiBolt run even smoother.
 
 ---
 
-## Labels
-
-Labels are located at the top of each guide to help you
-
-* The first label indicate how difficult is the bonus guide in term of installation procedure and/or use
-
-Difficulty: Easy
-{: .label .label-green }
-
-Difficulty: Intermediate
-{: .label .label-yellow }
-
-Difficulty: Hard
-{: .label .label-red }
-
-* The second label tells you if the guide has been updated and tested on the RaspiBolt v3. If it has been tested, you should be able to follow the guide without encountering any issues. If it has not been tested and updated yet, you might have to modify part of the guide to make it work on a RaspiBolt v3.
-
-Status: Tested v3
-{: .label .label-green }
-
-Status: Not tested v3
-{: .label .label-yellow }
-
----
-
-## Table of contents
-{: .no_toc .text-delta }
+## Bonus guide categories
 
 * **[Raspberry Pi](raspberry-pi/index.md)**
 * **[Bitcoin](bitcoin/index.md)**
 * **[Lightning](lightning/index.md)**
+
+## Rating
+
+All bonus guides are rated with labels to help you assess the difficulty of each guide, and if it is tested against the most recent version of the main guide.
+
+* Difficulty: indicates how difficult the bonus guide is in term of installation procedure or usage
+  
+  Difficulty: Easy
+  {: .label .label-green }
+
+  Difficulty: Medium
+  {: .label .label-yellow }
+
+  Difficulty: Hard
+  {: .label .label-red }
+
+* Tested: indicates if the guide has been updated and tested on the RaspiBolt v3. If this is not the case, you might have to modify part of the guide to make it work on a RaspiBolt v3.
+
+  Status: Tested v3
+  {: .label .label-green }
+  
+  Status: Not tested v3
+  {: .label .label-yellow }
 
 <br /><br />
 

--- a/bonus/index.md
+++ b/bonus/index.md
@@ -20,6 +20,8 @@ In the following categories, you can find various additional and optional guides
 * **[Bitcoin](bitcoin/index.md)**
 * **[Lightning](lightning/index.md)**
 
+---
+
 ## Rating
 
 All bonus guides are rated with labels to help you assess the difficulty of each guide, and if it is tested against the most recent version of the main guide.

--- a/bonus/index.md
+++ b/bonus/index.md
@@ -14,12 +14,41 @@ In this section, you can find various optional topics that make your RaspiBolt r
 
 🚨 This section is not maintained as frequently and not tested as thoroughly as the main part of the guide. To use with caution!
 
+---
+
+## Labels
+
+Labels are located at the top of each guide to help you
+
+* The first label indicate how difficult is the bonus guide in term of installation procedure and/or use
+
+Difficulty: Easy
+{: .label .label-green }
+
+Difficulty: Intermediate
+{: .label .label-yellow }
+
+Difficulty: Hard
+{: .label .label-red }
+
+* The second label tells you if the guide has been updated and tested on the RaspiBolt v3. If it has been tested, you should be able to follow the guide without encountering any issues. If it has not been tested and updated yet, you might have to modify part of the guide to make it work on a RaspiBolt v3.
+
+Status: Tested v3
+{: .label .label-green }
+
+Status: Not tested v3
+{: .label .label-yellow }
+
+---
+
 ## Table of contents
 {: .no_toc .text-delta }
 
 * **[Raspberry Pi](raspberry-pi/index.md)**
 * **[Bitcoin](bitcoin/index.md)**
 * **[Lightning](lightning/index.md)**
+
+<br /><br />
 
 ---
 

--- a/bonus/lightning/additional-scripts.md
+++ b/bonus/lightning/additional-scripts.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Easy
 {: .label .label-green }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/lightning/auto-unlock.md
+++ b/bonus/lightning/auto-unlock.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Intermediate
 {: .label .label-yellow }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 > Please note: this guide has not been updated to LND 0.5 yet and might not work as intended.
 
 It takes a litte getting used to the fact that the LND wallet needs  to be manually unlocked everytime the LND daemon is restarted. This  makes sense from a security perspective, as the wallet is encrypted and  the key is not stored on the same machine. For reliable operations,  however, this is not optimal, as you can easily recover LND after it  restarts for some reason (crash or power outage), but then it's stuck  with a locked wallet and cannot operate at all.

--- a/bonus/lightning/remote-lncli.md
+++ b/bonus/lightning/remote-lncli.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Easy
 {: .label .label-green }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/lightning/static-backup-dropbox.md
+++ b/bonus/lightning/static-backup-dropbox.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Easy
 {: .label .label-green }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/lightning/zap-ios.md
+++ b/bonus/lightning/zap-ios.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Intermediate
 {: .label .label-yellow }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/lightning/zap.md
+++ b/bonus/lightning/zap.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Easy
 {: .label .label-green }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/lightning/zeus-over-tor.md
+++ b/bonus/lightning/zeus-over-tor.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Intermediate
 {: .label .label-yellow }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 Download the Zeus app, APKs available here: https://github.com/ZeusLN/zeus/releases, 
 on F-Droid and Google Play.
 

--- a/bonus/raspberry-pi/command-line.md
+++ b/bonus/raspberry-pi/command-line.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Easy
 {: .label .label-green }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/raspberry-pi/odroid-setup.md
+++ b/bonus/raspberry-pi/odroid-setup.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Intermediate
 {: .label .label-yellow }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/raspberry-pi/system-overview.md
+++ b/bonus/raspberry-pi/system-overview.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Easy
 {: .label .label-green }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 To get a quick overview over the system status, I created [a shell script](resources/20-raspibolt-welcome) that is run as "message of the day" (motd) to be shown on login or on demand.
 
 ![MotD system overview](images/60_status_overview.png)

--- a/bonus/raspberry-pi/trezor-agent.md
+++ b/bonus/raspberry-pi/trezor-agent.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Easy
 {: .label .label-green }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/bonus/raspberry-pi/upgrade-external-drive.md
+++ b/bonus/raspberry-pi/upgrade-external-drive.md
@@ -13,6 +13,9 @@ has_toc: false
 Difficulty: Intermediate
 {: .label .label-yellow }
 
+Status: Not tested v3
+{: .label .label-yellow }
+
 <details open markdown="block">
   <summary>
     Table of contents


### PR DESCRIPTION
#### What

This PR adds a yellow 'Status: Not tested v3' label to all the untested legacy bonus guides.

It also add a 'Labels' section to the 'Bonus Section' index page that introduces the reader to the meaning of these labels.

For now, two categories of labels exist: Difficulty (Easy/green, Intermediate/yellow, Hard/red) and v3-tested status (tested/green or not tested/yellow). More labels could be added later on if judged useful.

### Why

To warn readers that a bonus guide might not work on a RaspiBolt v3 and might require some slight or heavy adaptions to make it work.

#### How

Added the yellow status label to all untested legacy guides.
Added a Label section to the bonus section. 

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Check that the label syntax is correct as they are not displayed in the Github preview.

#### Animated GIF (optional)

![label](https://media.giphy.com/media/IbfbsOEMw77mwlrSpk/giphy-downsized.gif)
