### PR TITLE
bitcoind: use 'startupnotify' for group perms

### DIFF
--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -173,10 +173,6 @@ We'll also set the proper access permissions.
   server=1
   txindex=1
 
-  # File permissions, necessary for cookie authentication
-  sysperms=1
-  disablewallet=1
-
   # Network
   listen=1
   listenonion=1
@@ -265,7 +261,8 @@ We use “systemd“, a daemon that controls the startup process using configura
   ExecStart=/usr/local/bin/bitcoind -daemon \
                                     -pid=/run/bitcoind/bitcoind.pid \
                                     -conf=/home/bitcoin/.bitcoin/bitcoin.conf \
-                                    -datadir=/home/bitcoin/.bitcoin
+                                    -datadir=/home/bitcoin/.bitcoin \
+                                    -startupnotify="chmod g+r /home/bitcoin/.bitcoin/.cookie"
 
   # Process management
   ####################
@@ -343,6 +340,14 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   > Nov 25 22:50:59 raspibolt3 systemd[1]: Starting Bitcoin daemon...
   > Nov 25 22:50:59 raspibolt3 bitcoind[2316]: Bitcoin Core starting
   > Nov 25 22:50:59 raspibolt3 systemd[1]: Started Bitcoin daemon.
+  ```
+
+* Check if the permission cookie can be accessed by the group "bitcoin".
+  The output must contain the `-rw-r-----` part, otherwise no application run by a different user can access Bitcoin Core.
+
+  ```sh
+  $ ls -la /home/bitcoin/.bitcoin/.cookie
+  > -rw-r----- 1 bitcoin bitcoin 75 Dec 17 13:48 /home/bitcoin/.bitcoin/.cookie
   ```
 
 * See "bitcoind" in action by monitoring its log file.


### PR DESCRIPTION
### What

This pull request changes the method to ensure that the .cookie file is group accessible.

### Why

Bitcoin Core is accessible to applications run by different users through the authentication cookie. Users that are a member of the group "bitcoin" need read-only access to /data/bitcoin/.cookie and can then authenticate themselves without username and password.

By default, Bitcoin Core does not create the .cookie file with group permissions. As of now, the bitcoind argument `sysperms=1`
is used with UMask=0027 to override this. Bitcoind only allows this if `disablewallet=1` is set. This breaks compatibility with
applications that rely on the Bitcoin Core wallet like JoinMarket or Electrum Personal Server.

### How

This change uses a different method that allows to keep the wallet enabled: executing a shell command after startup of bitcoind, configured with the argument `startupnotify` and triggered by bitcoind itself.

### Scope

- [x] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

Fixes #801

### Test & maintenance

* Make sure Bitcoin Core is configured to use the `rpcauth` method [used in the RaspBolt v3](https://raspibolt.org/bitcoin-core.html#generate-access-credentials), and not the `rpcuser` / `rpcpassword` of older guides
* Disable the following options in the `bitcoin.conf` file:
  ```
  #sysperms=1
  #disablewallet=1
  ```
* Restart Bitcoin Core and make sure the `.cookie` file is generated. The `-rw-------` part means that only the user "bitcoin", but not the group "bitcoin" has (r)ead and (w)rite access to the file. For more context, see the comments above.
  ```
  $ sudo systemctl restart bitcoind
  $ $ ls -la /data/bitcoin | grep .cookie
  > -rw------- 1 bitcoin bitcoin      75 Dec 12 12:25 .cookie
  ```
* Update the file `/etc/systemd/system/bitcoind.service` according to this pull request.

* Reload the system unit and restart Bitcoin Core again. Then check if the group "bitcoin" now has (r)ead access to the file, as the additional `r` indicates in the output below (this can take several seconds):
  ```
  $ sudo systemctl daemon-reload
  $ sudo systemctl restart bitcoind
  $ watch ls -la /data/bitcoin/.cookie
  > -rw-r----- 1 bitcoin bitcoin      75 Dec 12 12:25 .cookie

  ```

#### Animated GIF (optional)

![](https://media.giphy.com/media/bAlYQOugzX9sY/giphy.gif)