### PR TITLE
Add mission control permission to macaroons table

### DIFF
--- a/bonus/lightning/remote-lncli.md
+++ b/bonus/lightning/remote-lncli.md
@@ -161,6 +161,8 @@ The table below shows which commands are permitted by each macaroon
 |feereport|Yes|Yes|No|
 |updatechanpolicy|Yes|No|No|
 |fwdinghistory|Yes|Yes|No|
+|resetmc|Yes|No|No|
+|querymc|Yes|Yes|No|
 
 *Guide by robclark56, thanks!*
 


### PR DESCRIPTION
## Description

I added the permissions allowed/denied for the two mission control functions (`querymc` and `resetmc`) to the macaroons permissions table.