### PR TITLE
system overview: re-add netcat

### DIFF
--- a/bonus/raspberry-pi/system-overview.md
+++ b/bonus/raspberry-pi/system-overview.md
@@ -30,7 +30,7 @@ This script can be run by user "admin" without root privileges, but you should s
 * Install necessary software packages
 
   ```sh
-  $ sudo apt install jq net-tools
+  $ sudo apt install jq net-tools netcat
   ```
 
 * Download the script.


### PR DESCRIPTION
When updating the system overview, netcat was removed by mistake.
This commit adds it again.

Reported by https://twitter.com/AsyncLuck/status/1473714386162302978

![](https://media.giphy.com/media/xT5LMpBWU96Yivdfeo/giphy.gif)
