### PR TITLE
Update bitcoin-core.md

### DIFF
--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -365,6 +365,15 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
     That’s normal, just give it a few minutes.
   * Among other infos, the “verificationprogress” is shown.
     Once this value reaches almost 1 (0.999…), the blockchain is up-to-date and fully validated.
+  * If you see the following warning when inspecting the bitcoin service with `systemctl status bitcoind.service`:
+    ```
+    Warning: some journal files were not opened due to insufficient permissions.
+    ```
+    Then run the following command to give read access to all users in the bitcoin group:
+    ```
+    $ sudo chmod -R g+r /data/bitcoin
+    ```
+    
 
 ---
 


### PR DESCRIPTION
#### What

What is the reason of this change?

Following the guide here [at this point](https://raspibolt.org/bitcoin-core.html#verification-of-bitcoind-operations), I ran the command `systemctl status bitcoind.service` and saw the following results and warning:

```
admin@raspibolt3:~/.bitcoin $ systemctl status bitcoind.service
* bitcoind.service - Bitcoin daemon
     Loaded: loaded (/etc/systemd/system/bitcoind.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2021-12-30 23:15:37 EST; 5min ago
    Process: 786 ExecStart=/usr/local/bin/bitcoind -daemon -pid=/run/bitcoind/bitcoind.pid -conf=/home/bitcoin/.bitcoin/bitcoin.conf -datadir=/home/bitcoin/.bitcoin -startupnotify=chmod g>
   Main PID: 787 (bitcoind)
      Tasks: 17 (limit: 4165)
        CPU: 6.324s
     CGroup: /system.slice/bitcoind.service
             `-787 /usr/local/bin/bitcoind -daemon -pid=/run/bitcoind/bitcoind.pid -conf=/home/bitcoin/.bitcoin/bitcoin.conf -datadir=/home/bitcoin/.bitcoin -startupnotify=chmod g+r /home>

Warning: some journal files were not opened due to insufficient permissions.
```

Next I noted that the cookie had the correct read permissions on the group.

Next I failed to view the debug log:
```
admin@raspibolt3:~/.bitcoin $ tail -f /home/bitcoin/.bitcoin/debug.log
tail: cannot open '/home/bitcoin/.bitcoin/debug.log' for reading: Permission denied
tail: no files remaining
```

Next I noticed that not all the files in the `~/.bitcoin` directory had the read permission for the bitcoin group.

I modified the group read permissions recursively on the directory with the command:
```
$ sudo chmod -R g+r /data/bitcoin
```

Then I was able to tail the log and the warning no longer appeared after restarting the bitcoind service.

### Why

Why is this change important?

All users in the bitcoin group should be able to access all the files in the bitcoin data directory.

#### How

Recursively modifying the group read permissions on all files in the bitcoin data directory.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes #864 

#### Test & maintenance
The changes can be tested by running the command and verifying that they can tail the debug.log file and no warning appears when inspecting the bitcoind service.

#### Animated GIF (optional)

![](https://media.giphy.com/media/9kxpWjuRWISLC/giphy.gif)
