### PR TITLE
Update bitcoin-core.md: include warning and sudo when tailing debug.log

### DIFF
--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -337,6 +337,7 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   >      CGroup: /system.slice/bitcoind.service
   >              `-2317 /usr/local/bin/bitcoind -daemon -pid=/run/bitcoind/bitcoind.pid -conf=/home/bitcoin/.bitcoin/bitcoin.conf > -datadir=/home/bitcoin/.bitcoin
   >
+  > Warning: some journal files were not opened due to insufficient permissions.
   ```
 
 * Check if the permission cookie can be accessed by the group "bitcoin".
@@ -351,7 +352,7 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   Exit with `Ctrl-C`
 
   ```sh
-  $ tail -f /home/bitcoin/.bitcoin/debug.log
+  $ sudo tail -f /home/bitcoin/.bitcoin/debug.log
   ```
 
 * Use the Bitcoin Core client `bitcoin-cli` to get information about the current blockchain

--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -220,6 +220,12 @@ Still logged in as user "bitcoin", let's start "bitcoind" manually.
 
 * Once everything looks ok, stop "bitcoind" with `Ctrl-C`
 
+* Grant the "bitcoin" group read-permission for the debug log file:
+  
+  ```sh
+  $ sudo chmod g+r /data/bitcoin/debug.log
+  ```
+
 * Exit the “bitcoin” user session back to user “admin”
 
   ```sh
@@ -337,7 +343,6 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   >      CGroup: /system.slice/bitcoind.service
   >              `-2317 /usr/local/bin/bitcoind -daemon -pid=/run/bitcoind/bitcoind.pid -conf=/home/bitcoin/.bitcoin/bitcoin.conf > -datadir=/home/bitcoin/.bitcoin
   >
-  > Warning: some journal files were not opened due to insufficient permissions.
   ```
 
 * Check if the permission cookie can be accessed by the group "bitcoin".

--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -332,7 +332,7 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   Exit with `Ctrl-C`
 
   ```sh
-  $ systemctl status bitcoind.service
+  $ sudo systemctl status bitcoind.service
   > * bitcoind.service - Bitcoin daemon
   >      Loaded: loaded (/etc/systemd/system/bitcoind.service; enabled; vendor preset: enabled)
   >      Active: active (running) since Thu 2021-11-25 22:50:59 GMT; 7s ago

--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -223,7 +223,7 @@ Still logged in as user "bitcoin", let's start "bitcoind" manually.
 * Grant the "bitcoin" group read-permission for the debug log file:
   
   ```sh
-  $ sudo chmod g+r /data/bitcoin/debug.log
+  $ chmod g+r /data/bitcoin/debug.log
   ```
 
 * Exit the “bitcoin” user session back to user “admin”
@@ -357,7 +357,7 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   Exit with `Ctrl-C`
 
   ```sh
-  $ sudo tail -f /home/bitcoin/.bitcoin/debug.log
+  $ tail -f /home/bitcoin/.bitcoin/debug.log
   ```
 
 * Use the Bitcoin Core client `bitcoin-cli` to get information about the current blockchain


### PR DESCRIPTION
#### What

Adding an expected warning as well as prepending a command to use sudo.

This PR fixes #864 and succeeds #865 based on [this comment](https://github.com/raspibolt/raspibolt/issues/864#issuecomment-1003272244) by @c-mannix 

### Why

This change will prevent future confusion by users inspecting the bitcoind service and tailing the debug.log file.

#### How

* Now including the warning in the output
* Explicitly directing use of `sudo` with tail command
* 
#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes #864 

#### Test & maintenance

Test the command by running `tail -f /home/bitcoin/.bitcoin/debug.log` successfully.

#### Animated GIF (optional)

![](https://media.giphy.com/media/DJj4Bag0l7E3ZAcHHp/giphy.gif)
