### PR TITLE
Fix RTL broken link

### DIFF
--- a/rtl.md
+++ b/rtl.md
@@ -8,7 +8,7 @@ parent: Lightning
 # Ride The Lightning
 {: .no_toc }
 
-We install [Ride The Lightning](https://github.com/Ride-The-Lightning/RTL/blob/master/docs/README.md){:target="_blank"}, a powerful web interface to manage your Lightning node.
+We install [Ride The Lightning](https://github.com/Ride-The-Lightning/RTL#readme){:target="_blank"}, a powerful web interface to manage your Lightning node.
 
 ![Ride The Lightning dashboard](images/rtl-homepage.png)
 


### PR DESCRIPTION
#### What

A small fix for a broken link in the RTL guide.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Check that the new link is working and does not throw a 404 error.
