### PR TITLE
Update RTL guide to v0.12.0 (+ new sample configuration file location)

### DIFF
--- a/rtl.md
+++ b/rtl.md
@@ -104,12 +104,12 @@ We do not want to run Ride the Lightning alongside bitcoind and lnd because of s
   $ cd RTL
 
   $ git describe --tags --abbrev=0
-  > v0.11.2
+  > v0.12.0
 
-  $ git checkout v0.11.2
+  $ git checkout v0.12.0
 
-  $ git verify-tag v0.11.2
-  > gpg: Signature made Fri 03 Sep 2021 02:59:24 BST
+  $ git verify-tag v0.12.0
+  > gpg: Signature made Wed 29 Dec 2021 23:22:40 GMT
   > gpg:                using RSA key 3E9BD4436C288039CA827A9200C9E2BC2E45666F
   > gpg: Good signature from "saubyk (added uid) <39208279+saubyk@users.noreply.github.com>" [unknown]
   > gpg:                 aka "Suheb <39208279+saubyk@users.noreply.github.com>" [unknown]
@@ -150,7 +150,7 @@ Now we take the sample configuration file and add change it to our needs.
 * Copy the sample config file, and open it in the text editor.
 
   ```sh
-  cp docs/Sample-RTL-Config.json ./RTL-Config.json
+  cp .github/docs/Sample-RTL-Config.json ./RTL-Config.json
   nano RTL-Config.json
   ```
 


### PR DESCRIPTION
#### What

The PR updates the RTL guide to the newest version (v0.12.0) in the download and install section. It also fixes a breaking change: the location of the sample configuration file has been moved from `~/RTL/docs` to `~/RTL/.github/docs`

### Why

* To fix a breaking change
* To keep the guide up-to-date with latest version

#### How

Updated `rtl.md`

#### Scope

- [x] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Test: If possible, install RTL from scratch using the updated guide and check that the updated command and outputs are all ok.
Check that the new configuration file location is ok.

#### Animated GIF (optional)

![12](https://media.giphy.com/media/13qF1WWgsbbU9q/giphy.gif)
