### PR TITLE
Removed outdated reference in Electrs guide about deactivated Bitcoin Core wallet 

### DIFF
--- a/electrs.md
+++ b/electrs.md
@@ -26,7 +26,7 @@ We set up [Electrs](https://github.com/romanz/electrs/){:target="_blank"} to ser
 The best way to safekeep your bitcoin (meaning the best combination of security and usability) is to use a hardware wallet (like [BitBox](https://shiftcrypto.ch/bitbox02){:target="_blank"}, [Ledger](https://www.ledger.com){:target="_blank"} or [Trezor](https://trezor.io){:target="_blank"}) in combination with your own Bitcoin node.
 This gives you security, privacy and eliminates the need to trust a third party to verify transactions.
 
-Bitcoin Core on the RaspiBolt itself is not meant to hold funds, its wallet is deactivated.
+Bitcoin Core on the RaspiBolt itself is not meant to hold funds.
 
 One possibility to use Bitcoin Core with your Bitcoin wallets is to use an Electrum Server as middleware.
 It imports data from Bitcoin Core and provides it to software wallets supporting the Electrum protocol.


### PR DESCRIPTION
#### What

The Electrs guide mentionned that Bitcoin Core was not meant to hold funds and that its wallet was deactivated. However, this is not the case anymore since #846 . This PR removes the part of the sentence that mentions the deactivated wallet.

### Why

For consistency

#### How

Removed a few words in `electrs.md`

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Just check that the modified sentence is correct.
