### PR TITLE
Remove qrencode package installation from core guide as not used

### DIFF
--- a/system-configuration.md
+++ b/system-configuration.md
@@ -142,7 +142,7 @@ The “Advanced Packaging Tool” (apt) makes this easy.
 * Make sure that all necessary software packages are installed:
 
   ```sh
-  $ sudo apt install wget curl gpg git htop jq qrencode --install-recommends
+  $ sudo apt install wget curl gpg git htop jq --install-recommends
   ```
 
 ---


### PR DESCRIPTION
#### What

This PR is a proposal to remove the installation of the `qrencode` package in the core guide.

Note: what about `jq`, do we use it in the core guide..? I can't find where.

### Why

The package is not used at any point in the core guide, so no reason to install it by default (security risk)

#### How

Deletedt the package name from the command

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Just need to make sure that we indeed do not need this package anywhere in the core guide

#### Animated GIF (optional)

![QR](https://media.giphy.com/media/2X9KCY4LGV9ok/giphy.gif)
