### PR TITLE
Fixed path to RTL sample config file

### DIFF
--- a/rtl.md
+++ b/rtl.md
@@ -149,7 +149,7 @@ Now we take the sample configuration file and add change it to our needs.
 * Copy the sample config file, and open it in the text editor.
 
   ```sh
-  cp docs/Sample-RTL-Config.json ./RTL-Config.json
+  cp Sample-RTL-Config.json ./RTL-Config.json
   nano RTL-Config.json
   ```
 


### PR DESCRIPTION
#### What

Fix the path of RTL sample config file.

### Why

The sample file has once again moved location (it was recently put in the `/docs` directory which does not exist anymore and it's back in the root directory).

#### How

fixed path

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Check that the corrected path is the right one
