### PR TITLE
Updated list of default packages to install

### DIFF
--- a/bonus/bitcoin/white-paper.md
+++ b/bonus/bitcoin/white-paper.md
@@ -51,6 +51,13 @@ This guide explains how to reconstruct the Bitcoin white paper PDF using your ow
   $ mkdir bitcoin-white-paper
   $ cd bitcoin-white-paper
   ```
+  
+* Install jq, a JSON processor that will be used to parse the transaction data
+
+  ```sh
+  $ sudo apt update
+  $ sudo apt install jq --install-recommends
+  ```
 
 * Use `bitcoin-cli` to download and create the PDF
 

--- a/bonus/bitcoin/white-paper.md
+++ b/bonus/bitcoin/white-paper.md
@@ -52,7 +52,7 @@ This guide explains how to reconstruct the Bitcoin white paper PDF using your ow
   $ cd bitcoin-white-paper
   ```
   
-* Install jq, a JSON processor that will be used to parse the transaction data
+* Install `jq`, a JSON processor that will be used to parse the transaction data
 
   ```sh
   $ sudo apt update

--- a/bonus/lightning/additional-scripts.md
+++ b/bonus/lightning/additional-scripts.md
@@ -27,9 +27,10 @@ Status: Not tested v3
 
 The following scripts were created by [RobClark56](https://github.com/robclark56) and help getting a better system overview.
 
-Install necessary software packages:
+Install `jq`, a JSON processor that will be used by the scripts:
 
   ```sh
+  $ sudo apt update
   $ sudo apt install jq --install-recommends
   ```
 

--- a/bonus/lightning/additional-scripts.md
+++ b/bonus/lightning/additional-scripts.md
@@ -27,6 +27,12 @@ Status: Not tested v3
 
 The following scripts were created by [RobClark56](https://github.com/robclark56) and help getting a better system overview.
 
+Install necessary software packages:
+
+  ```sh
+  $ sudo apt install jq --install-recommends
+  ```
+
 As user "admin", download the scripts, make them executable and copy them to the global bin folder.
 
 ### Balance

--- a/system-configuration.md
+++ b/system-configuration.md
@@ -139,10 +139,10 @@ The “Advanced Packaging Tool” (apt) makes this easy.
 
   💡 Do this regularly every few months to get security-related updates.
 
-* Install `git`, a distributed version control system that will be used to install electrs, the block explorer and Ride The Lightning
+* Make sure that all necessary software packages are installed:
 
   ```sh
-  $ sudo apt install git --install-recommends
+  $ sudo apt install wget curl gpg git --install-recommends
   ```
 
 ---

--- a/system-configuration.md
+++ b/system-configuration.md
@@ -139,10 +139,10 @@ The “Advanced Packaging Tool” (apt) makes this easy.
 
   💡 Do this regularly every few months to get security-related updates.
 
-* Make sure that all necessary software packages are installed:
+* Install `git`, a distributed version control system that will be used to install electrs, the block explorer and Ride The Lightning
 
   ```sh
-  $ sudo apt install wget curl gpg git htop jq --install-recommends
+  $ sudo apt install git --install-recommends
   ```
 
 ---


### PR DESCRIPTION
#### What

This is a proposal to update the list of packages we install in the "System configuration" of the guide: probably only `git` need to be installed.

### Why

Presently, the command installs the following packages: `wget` `curl` `gpg` `git` `htop` `jq` 

* Based on the [list of packages included in RaspiOS Lite 64-bit](https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2022-01-28/2022-01-28-raspios-bullseye-arm64-lite.info), `wget`, `curl`, `gpg` and `htop` are already shipped with the OS and therefore do probably not need to be installed (moreover, `htop` is never used in the core guide)... or do they..?

* `jq` is not part of the OS but is not used in the core guide, only in bonus guides (albeit several of them: system overview, white paper, lnchannels, lnbalance). Therefore, `jq` should probably be installed only by users that want to install one of the bonus guide.

* `git`: git is used in the core guide to install electrs, the block explorer and RTL and therefore needs to be installed

Wdyat?

#### How

* Updated the command to install `git` only and updated the overlying comment accordingly.
* Added a `jq` installation step for the bonus guides that depends on it

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Make sure the removed packages are indeed already part of the OS or never used in the core guide.

#### Animated GIF (optional)

![packages](https://media.giphy.com/media/jYmGmDK3rKdkk/giphy.gif)
