### PR TITLE
/data owned by admin, and bitcoin user creation belongs in the Bitcoin section

### DIFF
--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -95,7 +95,7 @@ You can read more on [How to securely install Bitcoin](https://medium.com/@luked
 The Bitcoin Core application will run in the background as a daemon and use the separate user “bitcoin” for security reasons.
 This user does not have admin rights and cannot change the system configuration.
 
-* Create the user "bitcoin"
+* With user "admin", create the Bitcoin data folder
 
   ```sh
   $ sudo adduser --gecos "" --disabled-password bitcoin

--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -95,7 +95,7 @@ You can read more on [How to securely install Bitcoin](https://medium.com/@luked
 The Bitcoin Core application will run in the background as a daemon and use the separate user “bitcoin” for security reasons.
 This user does not have admin rights and cannot change the system configuration.
 
-* With user "admin", create the Bitcoin data folder
+* Create the user bitcoin
 
   ```sh
   $ sudo adduser --gecos "" --disabled-password bitcoin
@@ -116,7 +116,7 @@ Instead of creating this directory, we create a data directory in the general da
 
   ```sh
   $ mkdir /data/bitcoin
-  $ chown bitcoin. /data/bitcoin
+  $ chown bitcoin:bitcoin /data/bitcoin
   ```
 
 * Switch to user "bitcoin"
@@ -126,7 +126,7 @@ Instead of creating this directory, we create a data directory in the general da
   ```
 
 * Create the symbolic link `.bitcoin` that points to that directory
-`
+
   ```sh
   $ ln -s /data/bitcoin /home/bitcoin/.bitcoin
   ```

--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -90,11 +90,40 @@ This is a precaution to make sure that this is an official release and not a mal
 🔍 *Verifying signed software is important, not only for Bitcoin.
 You can read more on [How to securely install Bitcoin](https://medium.com/@lukedashjr/how-to-securely-install-bitcoin-9bfeca7d3b2a){:target="_blank"} by Luke-Jr.*
 
+### Create the bitcoin user
+
+The Bitcoin Core application will run in the background as a daemon and use the separate user “bitcoin” for security reasons.
+This user does not have admin rights and cannot change the system configuration.
+
+* Create the user "bitcoin"
+
+  ```sh
+  $ sudo adduser --gecos "" --disabled-password bitcoin
+  ```
+
+* Add the user "admin" to the group "bitcoin" as well
+
+  ```sh
+  $ sudo adduser admin bitcoin
+  ```
 
 ### Create data folder
 
 Bitcoin Core uses by default the folder `.bitcoin` in the user's home.
 Instead of creating this directory, we create a data directory in the general data location `/data` and link to it.
+
+* Switch to user "admin"
+
+  ```sh
+  $ sudo su - admin
+  ```
+
+* Create the Bitcoin data folder
+
+  ```sh
+  $ mkdir /data/bitcoin
+  $ chown bitcoin. /data/bitcoin
+  ```
 
 * Switch to user "bitcoin"
 
@@ -102,14 +131,8 @@ Instead of creating this directory, we create a data directory in the general da
   $ sudo su - bitcoin
   ```
 
-* Create the Bitcoin data folder
-
-  ```sh
-  $ mkdir /data/bitcoin
-  ```
-
 * Create the symbolic link `.bitcoin` that points to that directory
-
+`
   ```sh
   $ ln -s /data/bitcoin /home/bitcoin/.bitcoin
   ```

--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -112,12 +112,6 @@ This user does not have admin rights and cannot change the system configuration.
 Bitcoin Core uses by default the folder `.bitcoin` in the user's home.
 Instead of creating this directory, we create a data directory in the general data location `/data` and link to it.
 
-* Switch to user "admin"
-
-  ```sh
-  $ sudo su - admin
-  ```
-
 * Create the Bitcoin data folder
 
   ```sh

--- a/system-configuration.md
+++ b/system-configuration.md
@@ -131,7 +131,6 @@ Additionally, it's easier to move that directory somewhere else, for instance to
 
   ```sh
   $ sudo mkdir /data
-  $ sudo chown admin. /data
   ```
 
 ---

--- a/system-configuration.md
+++ b/system-configuration.md
@@ -24,7 +24,7 @@ Let's start with the configuration.
 
 ---
 
-## Add users
+## Add the admin user
 
 We will use the primary user "admin" instead of "pi" to make this guide more universal.
 
@@ -46,21 +46,6 @@ We will use the primary user "admin" instead of "pi" to make this guide more uni
 
   ```sh
   $ sudo adduser admin sudo
-  ```
-
-The Bitcoin Core application will run in the background (as a "daemon") and use the separate user “bitcoin” for security reasons.
-This user does not have admin rights and cannot change the system configuration.
-
-* Create the user "bitcoin"
-
-  ```sh
-  $ sudo adduser --gecos "" --disabled-password bitcoin
-  ```
-
-* Add the user "admin" to the group "bitcoin" as well
-
-  ```sh
-  $ sudo adduser admin bitcoin
   ```
 
 ---
@@ -153,11 +138,11 @@ We'll store all application data in the dedicated directory `/data/`.
 This allows for better security because it's not inside any user's home directory.
 Additionally, it's easier to move that directory somewhere else, for instance to a separate drive, as you can just mount any storage option to `/data/`.
 
-* Create the directory and make user "bitcoin" its owner
+* Create the directory and make user "admin" its owner
 
   ```sh
   $ sudo mkdir /data
-  $ sudo chown bitcoin:bitcoin /data
+  $ sudo chown admin. /data
   ```
 
 ---

--- a/system-configuration.md
+++ b/system-configuration.md
@@ -48,6 +48,17 @@ We will use the primary user "admin" instead of "pi" to make this guide more uni
   $ sudo adduser admin sudo
   ```
 
+* Logout from the `pi` user... `admin` will be used from that point forward
+
+  ```sh
+  $ exit
+  ```
+
+* Create a new connection with the `admin` user
+
+  Use the same [technique used previously](/remote-access.html#access-with-secure-shell) to 
+  login with `admin` instead of `pi`
+
 ---
 
 ## Check USB3 drive performance

--- a/system-configuration.md
+++ b/system-configuration.md
@@ -104,17 +104,6 @@ The “Advanced Packaging Tool” (apt) makes this easy.
   $ ssh admin@raspibolt.local
   ```
 
-  To change the system configuration and files that don't belong to the "admin", you have to prefix commands with `sudo`.
-  You will be prompted to enter your admin password from time to time for increased security.
-
-* Instruct your shell to always use the default language settings.
-  This prevents annoying error messages.
-
-  ```sh
-  $ echo "export LC_ALL=C" >> ~/.bashrc
-  $ source ~/.bashrc
-  ```
-
 * Update the operating system and all installed software packages
 
   ```sh

--- a/system-configuration.md
+++ b/system-configuration.md
@@ -60,43 +60,6 @@ You will be prompted to enter your admin password from time to time for increase
 
 ---
 
-## Check USB3 drive performance
-
-A performant USB3 drive is essential for your node.
-The Raspberry Pi 4 supports these out of the box, but is a bit picky.
-Some USB3 adapters for external drives are not compatible and need a workaround to be usable.
-
-Let's check if your drive works well as-is, or if additional configuration is needed.
-
-* Install the software to measure the performance of your drive
-
-  ```sh
-  $ sudo apt update
-  $ sudo apt install hdparm
-  ```
-
-* Your external disk should be connected as `/dev/sda`.
-  Check if this is the case by listing the names of connected block devices
-
-  ```sh
-  $ lsblk -pli
-  ```
-
-* Measure the speed of your external drive
-
-  ```sh
-  $ sudo hdparm -t --direct /dev/sda
-  > Timing O_DIRECT disk reads: 932 MB in  3.00 seconds = 310.23 MB/sec
-  ```
-
-If the measured speed is more than 50 MB/s, you're good, no further action needed.
-
-If the speed of your USB3 drive is not acceptable, we need to configure the USB driver to ignore the UAS interface.
-
-Check the [Fix bad USB3 performance](troubleshooting.md#fix-bad-usb3-performance) entry in the Troubleshooting guide to learn how.
-
----
-
 ## System update
 
 It is important to keep the system up-to-date with security patches and application updates.
@@ -124,6 +87,42 @@ The “Advanced Packaging Tool” (apt) makes this easy.
   ```sh
   $ sudo apt install wget curl gpg git --install-recommends
   ```
+
+---
+
+## Check USB3 drive performance
+
+A performant USB3 drive is essential for your node.
+The Raspberry Pi 4 supports these out of the box, but is a bit picky.
+Some USB3 adapters for external drives are not compatible and need a workaround to be usable.
+
+Let's check if your drive works well as-is, or if additional configuration is needed.
+
+* Install the software to measure the performance of your drive
+
+  ```sh
+  $ sudo apt install hdparm
+  ```
+
+* Your external disk should be connected as `/dev/sda`.
+  Check if this is the case by listing the names of connected block devices
+
+  ```sh
+  $ lsblk -pli
+  ```
+
+* Measure the speed of your external drive
+
+  ```sh
+  $ sudo hdparm -t --direct /dev/sda
+  > Timing O_DIRECT disk reads: 932 MB in  3.00 seconds = 310.23 MB/sec
+  ```
+
+If the measured speed is more than 50 MB/s, you're good, no further action needed.
+
+If the speed of your USB3 drive is not acceptable, we need to configure the USB driver to ignore the UAS interface.
+
+Check the [Fix bad USB3 performance](troubleshooting.md#fix-bad-usb3-performance) entry in the Troubleshooting guide to learn how.
 
 ---
 

--- a/system-configuration.md
+++ b/system-configuration.md
@@ -24,17 +24,9 @@ Let's start with the configuration.
 
 ---
 
-## Add the admin user
+## Add the admin user (and log in with it)
 
 We will use the primary user "admin" instead of "pi" to make this guide more universal.
-
-* Instruct your shell (the command line) to always use the default language settings.
-  This prevents annoying error messages
-
-  ```sh
-  $ echo "export LC_ALL=C" >> ~/.bashrc
-  $ source ~/.bashrc
-  ```
 
 * Create a new user called "admin" with your `password [A]`
 
@@ -47,8 +39,9 @@ We will use the primary user "admin" instead of "pi" to make this guide more uni
   ```sh
   $ sudo adduser admin sudo
   ```
+  
 
-* Logout from the `pi` user... `admin` will be used from that point forward
+* Exit your current "pi" user session and exit SSH
 
   ```sh
   $ exit
@@ -56,8 +49,14 @@ We will use the primary user "admin" instead of "pi" to make this guide more uni
 
 * Create a new connection with the `admin` user
 
-  Use the same [technique used previously](/remote-access.html#access-with-secure-shell) to 
-  login with `admin` instead of `pi`
+* Log in again using SSH (see [Access with Secure Shell](remote-access.html#access-with-secure-shell) section), but now with the user "admin" and your `password [A]`
+
+  ```sh
+  $ ssh admin@raspibolt.local
+  ```
+
+To change the system configuration and files that don't belong to user "admin", you have to prefix commands with `sudo`.
+You will be prompted to enter your admin password from time to time for increased security.
 
 ---
 
@@ -100,19 +99,15 @@ Check the [Fix bad USB3 performance](troubleshooting.md#fix-bad-usb3-performance
 
 ## System update
 
-Exit your current "pi" user session and exit SSH
-
-```sh
-$ exit
-```
-
 It is important to keep the system up-to-date with security patches and application updates.
 The “Advanced Packaging Tool” (apt) makes this easy.
 
-* Log in again using SSH, but now with the user "admin" and  your `password [A]`
+* Instruct your shell to always use the default language settings.
+  This prevents annoying error messages.
 
   ```sh
-  $ ssh admin@raspibolt.local
+  $ echo "export LC_ALL=C" >> ~/.bashrc
+  $ source ~/.bashrc
   ```
 
 * Update the operating system and all installed software packages
@@ -138,7 +133,7 @@ We'll store all application data in the dedicated directory `/data/`.
 This allows for better security because it's not inside any user's home directory.
 Additionally, it's easier to move that directory somewhere else, for instance to a separate drive, as you can just mount any storage option to `/data/`.
 
-* Create the directory and make user "admin" its owner
+* Create the data directory
 
   ```sh
   $ sudo mkdir /data


### PR DESCRIPTION
/data owned by admin, and bitcoin user creation belongs in the Bitcoin section

#### What

Postpone the bitcoin user creation until it is being used

### Why

Considering writing a testnet version of the bitcoin section... it would be pretty similar except for the user creation. So to keeps things consistent, might be a good idea to create the bitcoin user in the Bitcoin section.

#### How

Removed the bitcoin user creation in the `System Configuration` section, moved it to the `Bitcoin` section. A tad below, in the former section, the `/data` folder was created and owned by the bitcoin user. This was part of another discussion, wondering if that's the right thing to do. As that user simply doesn't exist at that point anymore, it makes much more sense to give that folder to the `admin` user.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

I fear it might be a good idea to create a brand new Raspibolt from scratch to make sure it works.

