### PR TITLE
Removed outdated password reference in LND guide

### DIFF
--- a/lnd.md
+++ b/lnd.md
@@ -281,7 +281,7 @@ Once LND is started, the process waits for us to create the integrated Bitcoin w
   ...
   ```
 
-These 24 words (combined with your optional passphrase `password [D]`)  is all that you need to restore the Bitcoin on-chain wallet.
+These 24 words (combined with your optional passphrase)  is all that you need to restore the Bitcoin on-chain wallet.
 The current state of your channels, however, cannot be recreated from this seed.
 For this, the Static Channel Backup stored at `/data/lnd-backup/channel.backup` is updated continuously.
 


### PR DESCRIPTION
#### What

Removes an outdated reference to "Password [D]" in the LND guide (a relict from v2)

#### Why

Outdated reference that can confuse new users.

#### How

* Updated `lnd.md`

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Double-check that the modified sentence is correct.
