### PR TITLE
Small changes for Pi Imager guidelines

### DIFF
--- a/operating-system.md
+++ b/operating-system.md
@@ -33,11 +33,14 @@ As a result, it should work smoothly with Raspberry Pis while still being compat
 
 ## Get Raspberry Pi OS
 
-In order to write the operating system to the external drive, we will use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/){:target="_blank"} application, which has been updated to include the 64bit version of the operating system: follow "Choose OS" > "Raspberry Pi OS (Other)" > "Raspberry Pi OS Lite (64-bit)" to have the relevant image flashed to your drive.
+In order to write the operating system to the external drive, we will use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/){:target="_blank"} application v1.7+, which has been updated to include the 64-bit version of the operating system.
+
+* Start the Raspberry Pi Imager
+* Select "ChOOSE OS" > "Raspberry Pi OS (Other)" > "Raspberry Pi OS Lite (64-bit)" to have the relevant image flashed to your drive.
 
 ## Configure boot options
 
-Start the Raspberry Pi Imager and open the "Advanced options" by pressing the cogwheel in the bottom right corner of the application window:
+Open the "Advanced options" by pressing the cogwheel that has appeared in the bottom right corner of the application window:
 
 ![image](images/operating-system_imager-start.png)
 

--- a/operating-system.md
+++ b/operating-system.md
@@ -36,7 +36,7 @@ As a result, it should work smoothly with Raspberry Pis while still being compat
 In order to write the operating system to the external drive, we will use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/){:target="_blank"} application v1.7+, which has been updated to include the 64-bit version of the operating system.
 
 * Start the Raspberry Pi Imager
-* Select "ChOOSE OS" > "Raspberry Pi OS (Other)" > "Raspberry Pi OS Lite (64-bit)" to have the relevant image flashed to your drive.
+* Select "CHOOSE OS" > "Raspberry Pi OS (Other)" > "Raspberry Pi OS Lite (64-bit)" to have the relevant image flashed to your drive
 
 ## Configure boot options
 

--- a/operating-system.md
+++ b/operating-system.md
@@ -33,7 +33,7 @@ As a result, it should work smoothly with Raspberry Pis while still being compat
 
 ## Get Raspberry Pi OS
 
-In order to write the operating system to the external drive, we will use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/){:target="_blank"} application v1.7+, which has been updated to include the 64-bit version of the operating system.
+In order to write the operating system to the external drive, we will use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/){:target="_blank"} application v1.7+.
 
 * Start the Raspberry Pi Imager
 * Select "CHOOSE OS" > "Raspberry Pi OS (Other)" > "Raspberry Pi OS Lite (64-bit)" to have the relevant image flashed to your drive


### PR DESCRIPTION
#### What

Fixes a minor illogical statement in the Pi Imager section of the guide + adds a version requirement for the Imager

Specifically: 
* Adds that v1.7+ is required (no cogwheel in v1.6 and no advanced options at all in version below 1.6).
  * This addition is to reduce the numbers of users raising issues such as "Can't find the cogwheel" etc 
  * Instead of using "[...] we will use the Raspberry Pi imager v1.7+ [...]", we could use a sentence like "[...] we will use the latest version of the Raspberry Pi Imager [...]" which is maybe easier to read.. wdyt?
* Added implicit 'Start the Raspberry Pi Imager' to section where the OS is selected and used bullet points to make the commands clearer. And removed the 'Start the Raspberry Pi Imager' from the following section. as the Imager was already opened in the previous section.
  * This is the change that fixes the present-day slightly illogical wording and flow
* Added "that has appeared" to the cogwheel sentence (as it only appears when an advanced options-supporting OS is selected)... but can remove is this wording is judged akwkard or not really needed.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Ensure that the new version is logical and clearly worded.

![cogwheel](https://media.giphy.com/media/qcy6cSzrtP7ybXvZvn/giphy.gif)
