### PR TITLE
move tor-config for user bitcoin

### DIFF
--- a/bitcoin-core.md
+++ b/bitcoin-core.md
@@ -107,6 +107,12 @@ This user does not have admin rights and cannot change the system configuration.
   $ sudo adduser admin bitcoin
   ```
 
+* Allow the user "bitcoin" to configure Tor directly by adding it to the "debian-tor" group
+
+  ```sh
+  $ sudo adduser bitcoin debian-tor
+  ```
+
 ### Create data folder
 
 Bitcoin Core uses by default the folder `.bitcoin` in the user's home.
@@ -238,7 +244,7 @@ Still logged in as user "bitcoin", let's start "bitcoind" manually.
 * Once everything looks ok, stop "bitcoind" with `Ctrl-C`
 
 * Grant the "bitcoin" group read-permission for the debug log file:
-  
+
   ```sh
   $ chmod g+r /data/bitcoin/debug.log
   ```

--- a/privacy.md
+++ b/privacy.md
@@ -78,12 +78,6 @@ We need to enable Tor to accept instructions through its control port, with the 
   $ sudo systemctl reload tor
   ```
 
-* Allow the user "bitcoin" to configure Tor directly
-
-  ```sh
-  $ sudo adduser bitcoin debian-tor
-  ```
-
 Not all network traffic is routed over the Tor network.
 But we now have the base to configure sensitive applications to use it.
 


### PR DESCRIPTION
#### What

This change fixes https://github.com/raspibolt/raspibolt/issues/907

#### Why

It's a bug. We don't like bugs. 

#### How

https://github.com/raspibolt/raspibolt/pull/904 moves the creation of user "bitcoin" to the "Bitcoin Core" section. The command to add user "bitcoin" to group "debian-tor" is moved to this section as well.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes https://github.com/raspibolt/raspibolt/issues/907

#### Test & maintenance

Should be straight-forward
