### PR TITLE
Update privacy.md

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -124,7 +124,7 @@ A few examples:
 
 * **Windows**: configure PuTTY as described in this guide [Torifying PuTTY](https://gitlab.torproject.org/legacy/trac/-/wikis/doc/TorifyHOWTO/Putty){:target="_blank"} by the Tor Project.
 
-  * **Note:** If you are using Putty and fail to connect to your pi by setting port 9050 in the Putty proxy settings, try setting port 9150 instead.
+  * **Note:** If you are using PuTTy and fail to connect to your Pi by setting port 9050 in the PuTTy proxy settings, try setting port 9150 instead.
   * Also make sure to run Tor in the background by installing and running the Tor browser.
 
 * **MacOS and Linux**: use `torify` or `torsocks`.

--- a/privacy.md
+++ b/privacy.md
@@ -124,8 +124,7 @@ A few examples:
 
 * **Windows**: configure PuTTY as described in this guide [Torifying PuTTY](https://gitlab.torproject.org/legacy/trac/-/wikis/doc/TorifyHOWTO/Putty){:target="_blank"} by the Tor Project.
 
-  * **Note:** If you are using PuTTy and fail to connect to your Pi by setting port 9050 in the PuTTy proxy settings, try setting port 9150 instead.
-  * Also make sure to run Tor in the background by installing and running the Tor browser.
+  * **Note:** If you are using PuTTy and fail to connect to your Pi by setting port 9050 in the PuTTy proxy settings, try setting port 9150 instead. When Tor runs as an installed application instead of a background process it uses port 9150.
 
 * **MacOS and Linux**: use `torify` or `torsocks`.
   Both work similarly; just use whatever you have available:

--- a/privacy.md
+++ b/privacy.md
@@ -124,6 +124,9 @@ A few examples:
 
 * **Windows**: configure PuTTY as described in this guide [Torifying PuTTY](https://gitlab.torproject.org/legacy/trac/-/wikis/doc/TorifyHOWTO/Putty){:target="_blank"} by the Tor Project.
 
+  * **Note:** If you are using Putty and fail to connect to your pi by setting port 9050 in the Putty proxy settings, try setting port 9150 instead.
+  * Also make sure to run Tor in the background by installing and running the Tor browser.
+
 * **MacOS and Linux**: use `torify` or `torsocks`.
   Both work similarly; just use whatever you have available:
 


### PR DESCRIPTION
#### What

When following the v3 RaspiBolt guide to (optionally) SSH in to the raspibolt via Tor I hit a problem when following the advice pointed to here:
https://gitlab.torproject.org/legacy/trac/-/wikis/doc/TorifyHOWTO/Putty

### Why

I was unable to connect to my pi node following the linked-to guide.
The advice on the linked-to page was to connect to port 9050 which didn't work for me.

#### How

Because I was SSHing via Putty through Tor on windows with Tor browser running, I think Tor browser used Tor Bundle with port 9150 rather than 9050?
I think this is just Tor browser-bundle specific. Tor itself still listens on 9050

#### Scope

- [x] simple bug fix

#### Test & maintenance

None