### PR TITLE
Fixed dead link in SCB guide (another one)

### DIFF
--- a/static-channel-backup.md
+++ b/static-channel-backup.md
@@ -228,7 +228,7 @@ We set up the backup script as a systemd service to run in the background and st
 
 ## Option 1: Local backup
 
-Follow this section if you want a local backup. If you only want a remote backup, skip to the [next section](https://raspibolt.org/static-channel-backup.html#(optional)-remote-backup).
+Follow this section if you want a local backup. If you only want a remote backup, skip to the [next section](https://raspibolt.org/static-channel-backup.html#option-2-remote-backup-preparations).
 
 ### Storage device size
 


### PR DESCRIPTION
#### What

Fixes dead link in SCB guide.

### Why
[Dead link identified here](https://github.com/raspibolt/raspibolt/issues/915#issuecomment-1042963750)

#### How

Replaced wrong URL with the right one

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Double-check the link is working.