### PR TITLE
Fixes bug with SCB repo cloning destination

### DIFF
--- a/static-channel-backup.md
+++ b/static-channel-backup.md
@@ -129,10 +129,10 @@ We create a shell script to monitor `channel.backup` and make a copy to our back
   REMOTE_BACKUP_ENABLED=false
 
   # Locations of source SCB file, formatted backup files and Git repo
-  SOURCEFILE="/home/lnd/.lnd/data/chain/bitcoin/mainnet/channel.backup"
+  SOURCEFILE="~/.lnd/data/chain/bitcoin/mainnet/channel.backup"
   LOCAL_BACKUP_FILE="/mnt/static-channel-backup-external/channel-$(date +"%Y%m%d-%H%M%S").backup"
-  GITREPO="/data/lnd/remote-lnd-backup"
-  REMOTE_BACKUP_FILE="/data/lnd/remote-lnd-backup/channel-$(date +"%Y%m%d-%H%M%S").backup"
+  GITREPO="~/.lnd/remote-lnd-backup"
+  REMOTE_BACKUP_FILE="~/.lnd/remote-lnd-backup/channel-$(date +"%Y%m%d-%H%M%S").backup"
 
 
   # Local backup function
@@ -351,7 +351,7 @@ Follow this section if you want a remote backup. If you already set up a local b
   ```sh
   $ git config --global user.name "RaspiBolt"
   $ git config --global user.email "raspibolt@dummyemail.com"
-  $ cd /data/lnd
+  $ cd ~/.lnd
   $ git clone git@github.com:YourUserName/remote-lnd-backup.git
   > Cloning into 'remote-lnd-backup'...
   > [...]

--- a/static-channel-backup.md
+++ b/static-channel-backup.md
@@ -346,13 +346,14 @@ Follow this section if you want a remote backup. If you already set up a local b
   * Tick the box "Allow write access" to enable this key to push changes to the repository
   * Click "Add key"
 
-* Set up global Git configuration values (the name and email are required but can be dummy values). Then, clone your newly created empty repository. Replace `YourUserName` with your own GitHub username. When prompted "Are you sure you want to continue connecting", type `yes` and press "Enter".
+* Set up global Git configuration values (the name and email are required but can be dummy values). Then, move to the LND data folder and clone your newly created empty repository. Replace `YourUserName` with your own GitHub username. When prompted "Are you sure you want to continue connecting", type `yes` and press "Enter".
 
   ```sh
   $ git config --global user.name "RaspiBolt"
   $ git config --global user.email "raspibolt@dummyemail.com"
+  $ cd /data/lnd
   $ git clone git@github.com:YourUserName/remote-lnd-backup.git
-  > Cloning into 'lnd-backup'...
+  > Cloning into 'remote-lnd-backup'...
   > [...]
   ```
 
@@ -361,7 +362,7 @@ Follow this section if you want a remote backup. If you already set up a local b
 * Still with user "lnd", enter your local Git repository, create a dummy file and push it to your remote GitHub repository
 
   ```sh
-  $ cd /data/lnd/remote-lnd-backup
+  $ cd remote-lnd-backup
   $ touch test
   $ git add .
   $ git commit -m "testing"


### PR DESCRIPTION
#### What

This PR fixes a bug related to the location of the local GitHub repository for the remote backup of the SCB. As it is, the repo is cloned in `/home/lnd` instead of `/data/lnd`

### Why

The remote backup guide does not work as is.

#### How

I propose a simple `cd /data/lnd` just before cloning the repo + some minor related changes due to this added step

An alternative would be to add a destination argument to the `git clone` command. However, I encountered some issues with this technique. So I wonder if moving first to the desired directory might not be more fool-proof..

Wdyat?

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes #928 

#### Test & maintenance

Try out the new commands and see if it works as intended.
