### PR TITLE
Bitcoin & LND data migration: added -og flag to rsync command + LND chown command

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -87,7 +87,7 @@ Once you set up your new RaspiBolt 3, restore your old LND node setup.
   $ lsblk -pli
   $ sudo mount /dev/sdb1 /mnt/thumbdrive/
   $ sudo rsync -rhvPog --append-verify /mnt/thumbdrive/lnd /data
-  $ sudo chown -r lnd:lnd /data/lnd
+  $ sudo chown -R lnd:lnd /data/lnd
   ```
 
 ### Backup & Restore Bitcoin data

--- a/faq.md
+++ b/faq.md
@@ -61,7 +61,7 @@ Copy it to a USB thumbdrive, so that you can restore it later.
 * Copy the whole LND data directory to the thumbdrive
 
   ```sh
-  $ sudo rsync -rhvP --append-verify /mnt/ext/lnd /mnt/thumbdrive/
+  $ sudo rsync -rhvPog --append-verify /mnt/ext/lnd /mnt/thumbdrive/
   ```
 
 * Also make sure to create a Static Channel Backup file and copy it to the thumbdrive
@@ -86,7 +86,8 @@ Once you set up your new RaspiBolt 3, restore your old LND node setup.
   $ sudo mkdir /mnt/thumbdrive
   $ lsblk -pli
   $ sudo mount /dev/sdb1 /mnt/thumbdrive/
-  $ sudo rsync -rhvP --append-verify /mnt/thumbdrive/lnd /data
+  $ sudo rsync -rhvPog --append-verify /mnt/thumbdrive/lnd /data
+  $ sudo chown -r lnd:lnd /data/lnd
   ```
 
 ### Backup & Restore Bitcoin data
@@ -101,13 +102,13 @@ When **Reusing the old drive** for your new node, you must first copy the data t
 * Example for network copy
 
     ```sh
-    $ rsync -rhvP --append-verify admin@raspibolt.local:/mnt/ext/bitcoin /your-local-directory
+    $ rsync -rhvPog --append-verify admin@raspibolt.local:/mnt/ext/bitcoin /your-local-directory
     ```
 
 * Example for local drive-to-drive copy with both drives mounted
 
     ```sh
-    $ rsync -rhvP --append-verify /mnt/old-raspibolt-drive/bitcoin /mnt/raspibolt-v3-drive/data
+    $ rsync -rhvPog --append-verify /mnt/old-raspibolt-drive/bitcoin /mnt/raspibolt-v3-drive/data
     ```
 
 ---


### PR DESCRIPTION
#### What

See discussion in #933. The PR adds presently missing guidelines concerning the ownership of the Bitcoin and LND data folders when migrating from v2 to v3.

### Why

To improve the change of users successfully migrating their data to a new node

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes #933 

![copy](https://media.giphy.com/media/YAy9NNu16pYYg/giphy.gif)