### PR TITLE
Add keysend option in lnd.conf

### DIFF
--- a/lnd.md
+++ b/lnd.md
@@ -174,6 +174,7 @@ To improve the security of your wallet, check out these more advanced methods:
   bitcoin.basefee=1000
   bitcoin.feerate=1
   minchansize=100000
+  accept-keysend=true
   accept-amp=true
   protocol.wumbo-channels=true
   protocol.no-anchors=false


### PR DESCRIPTION
#### What

This PR adds an option to `lnd.conf` to enable [keysend payments (send/receive)](https://docs.lightning.engineering/lightning-network-tools/lnd/send-messages-with-keysend).

The option is described here: https://github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf#L385-L388

### Why

To add a useful LND functionality by default.

#### How

* Added a single-line option in `lnd.conf`

#### Scope

- [ ] significant change to core configuration
- [x] minor change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

No test needed, maybe just check that there is no typos..
