### PR TITLE
charge-lnd: fix internal links

### DIFF
--- a/guide/bonus/lightning/charge-lnd.md
+++ b/guide/bonus/lightning/charge-lnd.md
@@ -240,7 +240,7 @@ Then exit the charge-lnd user.
   $ exit
   ```
 
-* Double-check the fee policy on all your channels (e.g. using [RTL](https://raspibolt.org/rtl.html) or [lntop](https://raspibolt.org/bonus/lightning/lntop.html)) to ensure that you are happy with the changes!
+* Double-check the fee policy on all your channels (e.g. using [RTL](../../lightning/web-app.md) or [lntop](lntop.md)) to ensure that you are happy with the changes!
 
 🔍: _To see all the possible policy types and options and some examples, check the charge-lnd [Github page](https://github.com/accumulator/charge-lnd#charge-lnd){:target="_blank"}._
 


### PR DESCRIPTION
#### What

This change fixes two internal links in the "charge-lnd" bonus guide.

### Why

The bonus guide used full URLs including the raspibolt.org domain, which we should avoid. I did not catch these broken links when testing the restructured guide in my own fork, as the links pointed to the not-yet-restructured public guide. 

#### How

This change fixes these two links by using relative paths, pointing to the local markdown files.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Check the links of the "charge-lnd" bonus guide.
