### PR TITLE
Fix for installing to correct path

### DIFF
--- a/guide/bonus/lightning/rebalance-lnd.md
+++ b/guide/bonus/lightning/rebalance-lnd.md
@@ -75,7 +75,7 @@ pip is not installed by default on Raspberry Pi OS Lite (64-bit), check if it is
   $ sudo su - rebalance-lnd
   $ git clone https://github.com/C-Otto/rebalance-lnd.git
   $ cd rebalance-lnd/
-  $ pip3 install -r requirements.txt
+  $ pip3 install -r requirements.txt .
   ```
 
 * Add the rebalance-lnd binary file location to PATH


### PR DESCRIPTION
Fixed issue where pip3 install fails to install to ~/.local/bin