### PR TITLE
Bump Go version to 1.17.8

### DIFF
--- a/guide/bonus/lightning/circuit-breaker.md
+++ b/guide/bonus/lightning/circuit-breaker.md
@@ -45,22 +45,22 @@ Table of contents
 
   ```sh
   $ cd /tmp
-  $ wget https://go.dev/dl/go1.17.7.linux-arm64.tar.gz
+  $ wget https://go.dev/dl/go1.17.8.linux-arm64.tar.gz
   ```
   
-* Check on the download page what is the SHA256 checksum of the file, e.g. for above: a5aa1ed17d45ee1d58b4a4099b12f8942acbd1dd09b2e9a6abb1c4898043c5f5. 
+* Check on the download page what is the SHA256 checksum of the file, e.g. for above: 57a9171682e297df1a5bd287be056ed0280195ad079af90af16dcad4f64710cb.
 Calculate the SHA256 hash of the downloaded file, it should be the same number as the one on the website
   
   ```sh 
-  $ sha256sum go1.17.7.linux-arm64.tar.gz
-  > a5aa1ed17d45ee1d58b4a4099b12f8942acbd1dd09b2e9a6abb1c4898043c5f5  go1.17.7.linux-arm64.tar.gz
+  $ sha256sum go1.17.8.linux-arm64.tar.gz
+  > 57a9171682e297df1a5bd287be056ed0280195ad079af90af16dcad4f64710cb  go1.17.8.linux-arm64.tar.gz
   ```
   
 * Install Go in the `/usr/local` directory
   
   ```sh 
-  $ sudo tar -xvf go1.17.7.linux-arm64.tar.gz -C /usr/local
-  $ rm go1.17.7.linux-arm64.tar.gz
+  $ sudo tar -xvf go1.17.8.linux-arm64.tar.gz -C /usr/local
+  $ rm go1.17.8.linux-arm64.tar.gz
   ```
 
 * Add the binary to `PATH` to not have to type the full path each time you are using it. For a global installation of Go (that users other than "admin" can use), open `/etc/profile`
@@ -85,7 +85,7 @@ Calculate the SHA256 hash of the downloaded file, it should be the same number a
 
   ```sh
   $ go version
-  > go version go1.17.7 linux/arm64
+  > go version go1.17.8 linux/arm64
   ```
 
 ---


### PR DESCRIPTION
Update to newest version. Affects "Circuit Breaker" bonus guide.