### PR TITLE
Mempool nginx startup

### DIFF
--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -399,7 +399,7 @@ We now need to modify the nginx configuration to create a web server for the web
   $ sudo nano /lib/systemd/system/nginx.service
   ```
 
-  Add this line to the nginx systemd configuration file under the `[Service]` section
+  Add this line under the `[Service]` section
 
   ```ini
   ExecStartPre=/bin/bash -c 'until host mempool.space; do sleep 1; done;'

--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -393,11 +393,13 @@ We now need to modify the nginx configuration to create a web server for the web
   }
   ```
 
-* Add this line to the nginx systemd configuration file under the `[Service]` section
+* Modify the nginx systemd configuration file
 
   ```bash
   $ sudo nano /lib/systemd/system/nginx.service
   ```
+
+  Add this line to the nginx systemd configuration file under the `[Service]` section
 
   ```ini
   ExecStartPre=/bin/bash -c 'until host mempool.space; do sleep 1; done;'

--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -393,6 +393,14 @@ We now need to modify the nginx configuration to create a web server for the web
   }
   ```
 
+* Add this line to the nginx systemd configuration file under the `[Service]` section
+
+  ```ini
+  ExecStartPre=/bin/bash -c 'until host mempool.space; do sleep 1; done;'
+  ```
+
+  There might already have an `ExecStartPre` statement and that's ok to have more than one.
+
 * Test and reload nginx configuration
   
   ```sh

--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -395,6 +395,10 @@ We now need to modify the nginx configuration to create a web server for the web
 
 * Add this line to the nginx systemd configuration file under the `[Service]` section
 
+  ```bash
+  $ sudo nano /lib/systemd/system/nginx.service
+  ```
+
   ```ini
   ExecStartPre=/bin/bash -c 'until host mempool.space; do sleep 1; done;'
   ```


### PR DESCRIPTION
#### What

nginx cannot start on boot due to a bug introduced in the Mempool setup

Related to issue #919 

### Why

The configuration tries to reach a remote website while the DNS server isn't yet ready to receive requests

#### How

In the systemd nginx config, add a prerequisite step that makes sure the query goes through

#### Scope

- [X] simple bug fix

Fixes # (link issue)

#### Test & maintenance

Restart the raspibolt and make sure the mempool site works at https://raspibolt:4081

#### Animated GIF (optional)

https://media.giphy.com/media/XSVyi8jXJcv4ZEvOas/giphy-downsized-large.gif
