### PR TITLE
LND Channel backup. Bug fixed. Motivated by Issue #958

### DIFF
--- a/guide/bonus/lightning/charge-lnd.md
+++ b/guide/bonus/lightning/charge-lnd.md
@@ -271,7 +271,7 @@ If asked, select the `/bin/nano` text editor (type 1 and enter)
   ##########################################
 
   # Run charge-lnd every 2 hours at the 21st minute; and log the updates in the /tmp/my_charge-lnd.log log file
-  21 */6 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/chargelnd/charge-lnd.config > /tmp/my-charge-lnd.log 2>&1; date >> /tmp/my-charge-lnd.log
+  21 */6 * * * /home/chargelnd/.local/bin/charge-lnd -c /home/chargelnd/charge-lnd.config > /tmp/my-charge-lnd.log 2>&1; date >> /tmp/my-charge-lnd.log
   ```
 
   * The stars and numbers at the start defines the interval at which the job will be run. You can double-check it by using this online tool: [https://crontab.guru](https://crontab.guru/#21_*/6_*_*_*){:target="_blank"}.

--- a/guide/bonus/lightning/charge-lnd.md
+++ b/guide/bonus/lightning/charge-lnd.md
@@ -164,13 +164,13 @@ For this example, we will use a policy that:
   #################################################
   # Charge-lnd - Automatic fee policy adjustement #
   #################################################
-  
+
   ## COMMANDS TO TEST YOUR FEE STRATEGY
   # ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --check
   # ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --dry-run
-  
+
   ## FEE STRATEGY
-  
+
   [1_defaults]
   # place holder for your defaults for your fee policies
   # no strategy, so this only sets some defaults
@@ -179,28 +179,28 @@ For this example, we will use a policy that:
   min_htlc_msat = 1000
   max_htlc_msat_ratio = 1
   time_lock_delta = 40
-  
+
   [2_9999_basefee_policy]
   # '9999BaseFee' should be evaluated first before other fees are set
   # e.g. if local balance is <500,000 sats, increase base fees very high
   chan.max_local_balance = 500000
   strategy = static
   base_fee_msat = 9999000
-  
+
   [3_ignore_policy]
   # This policy is for ignoring specific nodes (e.g. a LOOP channel that we want to control manually)
   # The pubkey of the choosen nodes have to be listed below, separated with a comma
   node.id = <node_pubkey_1>,
 	<node_pubkey_2>
   strategy = ignore
-  
+
   [4_low_fees_policy]
   node.id = <node_pubkey_3>,
 	<node_pubkey_4>,
 	<node_pubkey_5>
   strategy = static
   fee_ppm = 50
-  
+
   [5_high_fees_policy]
   node.id = <node_pubkey_6>,
 	<node_pubkey_7>
@@ -267,7 +267,7 @@ If asked, select the `/bin/nano` text editor (type 1 and enter)
   ##########################################
   # 1 - Fee policy updates with charge-lnd #
   ##########################################
-  
+
   # Run charge-lnd every 2 hours at the 21st minute; and log the updates in the /tmp/my_charge-lnd.log log file
   21 */6 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/chargelnd/charge-lnd.config > /tmp/my-charge-lnd.log 2>&1; date >> /tmp/my-charge-lnd.log
   ```

--- a/guide/bonus/lightning/charge-lnd.md
+++ b/guide/bonus/lightning/charge-lnd.md
@@ -164,10 +164,13 @@ For this example, we will use a policy that:
   #################################################
   # Charge-lnd - Automatic fee policy adjustement #
   #################################################
+  
   ## COMMANDS TO TEST YOUR FEE STRATEGY
   # ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --check
   # ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --dry-run
+  
   ## FEE STRATEGY
+  
   [1_defaults]
   # place holder for your defaults for your fee policies
   # no strategy, so this only sets some defaults
@@ -176,24 +179,28 @@ For this example, we will use a policy that:
   min_htlc_msat = 1000
   max_htlc_msat_ratio = 1
   time_lock_delta = 40
+  
   [2_9999_basefee_policy]
   # '9999BaseFee' should be evaluated first before other fees are set
   # e.g. if local balance is <500,000 sats, increase base fees very high
   chan.max_local_balance = 500000
   strategy = static
   base_fee_msat = 9999000
+  
   [3_ignore_policy]
   # This policy is for ignoring specific nodes (e.g. a LOOP channel that we want to control manually)
   # The pubkey of the choosen nodes have to be listed below, separated with a comma
   node.id = <node_pubkey_1>,
 	<node_pubkey_2>
   strategy = ignore
+  
   [4_low_fees_policy]
   node.id = <node_pubkey_3>,
 	<node_pubkey_4>,
 	<node_pubkey_5>
   strategy = static
   fee_ppm = 50
+  
   [5_high_fees_policy]
   node.id = <node_pubkey_6>,
 	<node_pubkey_7>
@@ -260,6 +267,7 @@ If asked, select the `/bin/nano` text editor (type 1 and enter)
   ##########################################
   # 1 - Fee policy updates with charge-lnd #
   ##########################################
+  
   # Run charge-lnd every 2 hours at the 21st minute; and log the updates in the /tmp/my_charge-lnd.log log file
   21 */6 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/chargelnd/charge-lnd.config > /tmp/my-charge-lnd.log 2>&1; date >> /tmp/my-charge-lnd.log
   ```

--- a/guide/bonus/lightning/charge-lnd.md
+++ b/guide/bonus/lightning/charge-lnd.md
@@ -103,24 +103,26 @@ Table of contents
 
   ```sh
   $ charge-lnd -h
-  > usage: charge-lnd [-h] [--lnddir LNDDIR] [--grpc GRPC]
-  >                  [--electrum-server ELECTRUM_SERVER] [--dry-run] [--check]
-  >                  [-v] -c CONFIG
+  > usage: charge-lnd [-h] [--lnddir LNDDIR] [--tlscert TLS_CERT_PATH]
+  >                  [--macaroon MACAROON_PATH] [--grpc GRPC] [--electrum-server ELECTRUM_SERVER]
+  >                  [--dry-run] [--check] [-v] -c CONFIG
   >
   > optional arguments:
-  >  -h, --help            show this help message and exit
-  >  --lnddir LNDDIR       (default ~/.lnd) lnd directory
-  >  --grpc GRPC           (default localhost:10009) lnd gRPC endpoint
-  >  --electrum-server ELECTRUM_SERVER
-  >                        (optional, no default) electrum server host:port .
-  >                        Needed for onchain_fee.
-  >  --dry-run             Do not perform actions (for testing), print what we
-  >                        would do to stdout
-  >  --check               Do not perform actions, only check config file for
-  >                        valid syntax
-  >  -v, --verbose         Be more verbose
-  >  -c CONFIG, --config CONFIG
-  >                        path to config file
+  > -h, --help            show this help message and exit
+  > --lnddir LNDDIR       (default ~/.lnd) lnd directory
+  > --tlscert TLS_CERT_PATH
+  >                       (default [lnddir]/tls.cert) path to lnd TLS certificate
+  > --macaroon MACAROON_PATH
+  >                       (default [lnddir]/data/chain/bitcoin/mainnet/charge-lnd.macaroon) path to lnd auth macaroon
+  > --grpc GRPC           (default localhost:10009) lnd gRPC endpoint
+  > --electrum-server ELECTRUM_SERVER
+  >                      (optional, no default) electrum server host:port[:s]. 
+  >                      Needed for onchain_fee. Append ':s' for SSL connection
+  > --dry-run             Do not perform actions (for testing), print what we would do to stdout
+  > --check               Do not perform actions, only check config file for valid syntax
+  > -v, --verbose         Be more verbose
+  > -c CONFIG, --config CONFIG
+  >                      path to config file
   ```
 
 * Create a symlink to the LND directory. Place it in the home directory of the "chargelnd" user to match the default LND directory used by charge-lnd (*i.e.* `~/.lnd`)

--- a/guide/bonus/lightning/charge-lnd.md
+++ b/guide/bonus/lightning/charge-lnd.md
@@ -103,26 +103,24 @@ Table of contents
 
   ```sh
   $ charge-lnd -h
-  > usage: charge-lnd [-h] [--lnddir LNDDIR] [--tlscert TLS_CERT_PATH]
-  >                  [--macaroon MACAROON_PATH] [--grpc GRPC] [--electrum-server ELECTRUM_SERVER]
-  >                  [--dry-run] [--check] [-v] -c CONFIG
+  > usage: charge-lnd [-h] [--lnddir LNDDIR] [--grpc GRPC]
+  >                  [--electrum-server ELECTRUM_SERVER] [--dry-run] [--check]
+  >                  [-v] -c CONFIG
   >
   > optional arguments:
-  > -h, --help            show this help message and exit
-  > --lnddir LNDDIR       (default ~/.lnd) lnd directory
-  > --tlscert TLS_CERT_PATH
-  >                       (default [lnddir]/tls.cert) path to lnd TLS certificate
-  > --macaroon MACAROON_PATH
-  >                       (default [lnddir]/data/chain/bitcoin/mainnet/charge-lnd.macaroon) path to lnd auth macaroon
-  > --grpc GRPC           (default localhost:10009) lnd gRPC endpoint
-  > --electrum-server ELECTRUM_SERVER
-  >                      (optional, no default) electrum server host:port[:s]. 
-  >                      Needed for onchain_fee. Append ':s' for SSL connection
-  > --dry-run             Do not perform actions (for testing), print what we would do to stdout
-  > --check               Do not perform actions, only check config file for valid syntax
-  > -v, --verbose         Be more verbose
-  > -c CONFIG, --config CONFIG
-  >                      path to config file
+  >  -h, --help            show this help message and exit
+  >  --lnddir LNDDIR       (default ~/.lnd) lnd directory
+  >  --grpc GRPC           (default localhost:10009) lnd gRPC endpoint
+  >  --electrum-server ELECTRUM_SERVER
+  >                        (optional, no default) electrum server host:port .
+  >                        Needed for onchain_fee.
+  >  --dry-run             Do not perform actions (for testing), print what we
+  >                        would do to stdout
+  >  --check               Do not perform actions, only check config file for
+  >                        valid syntax
+  >  -v, --verbose         Be more verbose
+  >  -c CONFIG, --config CONFIG
+  >                        path to config file
   ```
 
 * Create a symlink to the LND directory. Place it in the home directory of the "chargelnd" user to match the default LND directory used by charge-lnd (*i.e.* `~/.lnd`)
@@ -166,13 +164,10 @@ For this example, we will use a policy that:
   #################################################
   # Charge-lnd - Automatic fee policy adjustement #
   #################################################
-
   ## COMMANDS TO TEST YOUR FEE STRATEGY
   # ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --check
   # ~/.local/bin/charge-lnd -c ~/charge-lnd/charge-lnd.config --dry-run
-
   ## FEE STRATEGY
-
   [1_defaults]
   # place holder for your defaults for your fee policies
   # no strategy, so this only sets some defaults
@@ -181,28 +176,24 @@ For this example, we will use a policy that:
   min_htlc_msat = 1000
   max_htlc_msat_ratio = 1
   time_lock_delta = 40
-
   [2_9999_basefee_policy]
   # '9999BaseFee' should be evaluated first before other fees are set
   # e.g. if local balance is <500,000 sats, increase base fees very high
   chan.max_local_balance = 500000
   strategy = static
   base_fee_msat = 9999000
-
   [3_ignore_policy]
   # This policy is for ignoring specific nodes (e.g. a LOOP channel that we want to control manually)
   # The pubkey of the choosen nodes have to be listed below, separated with a comma
   node.id = <node_pubkey_1>,
 	<node_pubkey_2>
   strategy = ignore
-
   [4_low_fees_policy]
   node.id = <node_pubkey_3>,
 	<node_pubkey_4>,
 	<node_pubkey_5>
   strategy = static
   fee_ppm = 50
-
   [5_high_fees_policy]
   node.id = <node_pubkey_6>,
 	<node_pubkey_7>
@@ -269,9 +260,8 @@ If asked, select the `/bin/nano` text editor (type 1 and enter)
   ##########################################
   # 1 - Fee policy updates with charge-lnd #
   ##########################################
-
   # Run charge-lnd every 2 hours at the 21st minute; and log the updates in the /tmp/my_charge-lnd.log log file
-  21 */6 * * * /home/chargelnd/.local/bin/charge-lnd -c /home/chargelnd/charge-lnd.config > /tmp/my-charge-lnd.log 2>&1; date >> /tmp/my-charge-lnd.log
+  21 */6 * * * /home/charge-lnd/.local/bin/charge-lnd -c /home/chargelnd/charge-lnd.config > /tmp/my-charge-lnd.log 2>&1; date >> /tmp/my-charge-lnd.log
   ```
 
   * The stars and numbers at the start defines the interval at which the job will be run. You can double-check it by using this online tool: [https://crontab.guru](https://crontab.guru/#21_*/6_*_*_*){:target="_blank"}.

--- a/guide/lightning/channel-backup.md
+++ b/guide/lightning/channel-backup.md
@@ -73,7 +73,7 @@ We prepare a shell script that automatically updates the LND SCB file on a chang
 
 By default, LND saves the SCB file here: `~/.lnd/data/chain/bitcoin/mainnet/channel.backup`. Ensure that the `lnd.conf` does not contain the `backupfilepath` option that modifies the backup location (as was used in a previous version of the RaspiBolt v3).
 
-* With the "admin" user, check that your `lnd.conf` file does not contain this line. If so, delete it or comment it out.
+* With the "admin" user, check that your `lnd.conf` file does not contain this line. If so, delete it or comment it out and restart LND.
 
   ```sh
   $ sudo nano /data/lnd/lnd.conf
@@ -82,23 +82,6 @@ By default, LND saves the SCB file here: `~/.lnd/data/chain/bitcoin/mainnet/chan
   ```ini
   #backupfilepath=/data/lnd-backup/channel.backup
   ```
-
-There may also be a backup file `channel.backup` from a previous installation with a size of 0 Bytes and root access rights. If this file exists, it must be deleted. The backup file is correctly created with the access permissions of lnd the next time the LND is restarted.
-
-* Check if the file channel.backup exists with a size of 0 Bytes and root access rights
-
-  ```sh
-  $ ls -al ~/.lnd/data/chain/bitcoin/mainnet/channel.backup
-  >-rw-r--r-- 1 root root 0 Feb  1 09:58 /home/admin/.lnd/data/chain/bitcoin/mainnet/channel.backup
-  ```
-
-* If the file `~/.lnd/data/chain/bitcoin/mainnet/channel.backup` exists, then it must be removed:
-
-  ```sh
-  $ sudo rm ~/.lnd/data/chain/bitcoin/mainnet/channel.backup
-  ```
-
-* Now: Restart LND
 
   ```sh
   $ sudo systemctl restart lnd

--- a/guide/lightning/channel-backup.md
+++ b/guide/lightning/channel-backup.md
@@ -73,7 +73,7 @@ We prepare a shell script that automatically updates the LND SCB file on a chang
 
 By default, LND saves the SCB file here: `~/.lnd/data/chain/bitcoin/mainnet/channel.backup`. Ensure that the `lnd.conf` does not contain the `backupfilepath` option that modifies the backup location (as was used in a previous version of the RaspiBolt v3).
 
-* With the "admin" user, check that your `lnd.conf` file does not contain this line. If so, delete it or comment it out and restart LND.
+* With the "admin" user, check that your `lnd.conf` file does not contain this line. If so, delete it or comment it out.
 
   ```sh
   $ sudo nano /data/lnd/lnd.conf
@@ -82,6 +82,23 @@ By default, LND saves the SCB file here: `~/.lnd/data/chain/bitcoin/mainnet/chan
   ```ini
   #backupfilepath=/data/lnd-backup/channel.backup
   ```
+
+There may also be a backup file `channel.backup` from a previous installation with a size of 0 Bytes and root access rights. If this file exists, it must be deleted. The backup file is correctly created with the access permissions of lnd the next time the LND is restarted.
+
+* Check if the file channel.backup exists with a size of 0 Bytes and root access rights
+
+  ```sh
+  $ ls -al ~/.lnd/data/chain/bitcoin/mainnet/channel.backup
+  >-rw-r--r-- 1 root root 0 Feb  1 09:58 /home/admin/.lnd/data/chain/bitcoin/mainnet/channel.backup
+  ```
+
+* If the file `~/.lnd/data/chain/bitcoin/mainnet/channel.backup` exists, then it must be removed:
+
+  ```sh
+  $ sudo rm ~/.lnd/data/chain/bitcoin/mainnet/channel.backup
+  ```
+
+* Now: Restart LND
 
   ```sh
   $ sudo systemctl restart lnd
@@ -286,7 +303,7 @@ The `channel.backup` file is very small in size (<<1 MB) so even the smallest US
 
   ```sh
   $ sudo mount -a
-  $ df -h static-channel-backup-external
+  $ df -h /mnt/static-channel-backup-external
   > Filesystem      Size  Used Avail Use% Mounted on
   > /dev/sdb        1.9G  4.0K  1.9G   1% /mnt/static-channel-backup-external
   ```
@@ -343,7 +360,7 @@ Follow this section if you want a remote backup. If you already set up a local b
   ```
 
 * Go back to the GitHub repository webpage
-  * Click on "Settings", then "Deploy keys", then "Add deploy keys"
+  * Click on "Settings", then "Deploy keys", then "Add deploy key"
   * Type a title (e.g., "SCB")
   * In the "Key" box, copy/paste the string generated above starting (e.g. `ssh-rsa 5678efgh... lnd@raspibolt`)
   * Tick the box "Allow write access" to enable this key to push changes to the repository
@@ -442,7 +459,7 @@ Then we check if a copy gets stored at the intended backup location(s).
 * If you enabled the local backup, check the content of your local storage device. It should now contain a backup file with the date/time corresponding to the test made just above
 
   ```sh
-  $ ls -la /mnt/storage-device-scb
+  $ ls -la /mnt/static-channel-backup-external
   > -rwxr-xr-x 1 lnd  lnd  14011 Feb  5 10:59 channel-20220205-105949.backup
   ```
 


### PR DESCRIPTION
#### What

Based on the implemented backup option with Dropbox, I wanted to switch the backup to the new variants. At the same time I also wanted to make a pull request to fix issue #958. I found a few more small bugs and fixed them.

Fixes #958 
Fixes #981

So I got the following error messages because the file channel.backup exists with a size of 0 bytes and root access rights:

admin@raspibolt:~ $ ls -al ~/.lnd/data/chain/bitcoin/mainnet/channel.backup
-rw-r--r-- 1 root root 0 Feb  1 09:58 /home/admin/.lnd/data/chain/bitcoin/mainnet/channel.backup

......
Apr 10 17:29:04 raspibolt lnd[114726]: 2022-04-10 17:29:04.547 [ERR] LTND: Shutting down because error in main method: unable to start server: unable to refresh backup file: unable to extract on disk encrypted SCB: payload size too small, must be at least 24 bytes
Apr 10 17:29:04 raspibolt lnd[114726]: 2022-04-10 17:29:04.548 [INF] RPCS: Stopping RPC Server
......
Apr 10 17:29:26 raspibolt systemd[1]: Stopped LND Lightning Network Daemon.
Apr 10 17:29:26 raspibolt systemd[1]: lnd.service: Consumed 14.296s CPU time.

### Why

The imprecise path information is not easy to handle for users without Commandline knowledge.

#### How

I changed the text ;-)

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes #958

#### Test & maintenance

I implemented the installation according to the corrected guide

#### Animated GIF (optional)

Add some snazz if you feel like it :)

A fulfilling job