### PR TITLE
Several small bug fixes for Mempool bonus guide

### DIFF
--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -236,7 +236,7 @@ The Mempool configuration file contains the Bitcoin Core RPC username and passwo
 * Still with user "admin", change the ownership of the configuration file
  
   ```sh
-  $ sudo chown 600 /home/mempool/mempool/backend/mempool-config.json
+  $ sudo chmod 600 /home/mempool/mempool/backend/mempool-config.json
   ```
 
 ### nginx

--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -179,6 +179,14 @@ For improved security, we create the new user "mempool" that will run the Mempoo
       "USERNAME": "mempool",
       "PASSWORD": "mempool",
       "DATABASE": "mempool"
+    },
+    "SOCKS5PROXY": {
+      "ENABLED": true,
+      "HOST": "127.0.0.1",
+      "PORT": 9050
+    },
+    "PRICE_DATA_SERVER": {
+      "TOR_URL": "http://wizpriceje6q5tdrxkyiazsgu7irquiqjy2dptezqhrtu7l2qelqktid.onion/getAllMarketPrices"
     }
   }
   ```

--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -538,7 +538,7 @@ Updating to a new release is straight-forward. Make sure to read the release not
   $ sudo mv /etc/nginx/nginx.conf.bak2 /etc/nginx/nginx.conf
   ```
   
-* Test and reload NGINX configuration
+* Test and reload nginx configuration
   
   ```sh
   $ sudo nginx -t

--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -139,7 +139,7 @@ For improved security, we create the new user "mempool" that will run the Mempoo
   $ nano mempool-config.json
   ```
 
-* Paste the following lines. In the CORE_RPC section, replace the username with "raspibolt" and password with your password [B].
+* Paste the following lines. In the CORE_RPC section, replace the username and password with your username (e.g., "raspibolt") and password [B].
 
 
   ```sh

--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -35,10 +35,10 @@ Table of contents
 
 ## Requirements
 
-* Bitcoin
+* Minimum RAM: 4 GB
+* Bitcoin Core
 * Electrs
 * Node.js v16+
-* MariaDB
 * nginx
 
 ---


### PR DESCRIPTION
#### What

Several bug fixes for the Mempool bonus guide:
- Fixes #918 : states the requirement of running Mempool with a minimum of 4 GB of RAM
- Fixes #965 : add a Tor proxy in Mempool config to fetch prices privately
- Fixes #966 : fixed command typo: chown -> chmod 
- a couple of minor wording changes for improved clarity

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix
