### PR TITLE
Bump Electrs version and update command to fetch latest release tag

### DIFF
--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -100,7 +100,7 @@ We get the latest release of the Electrs source code, verify it, compile it to a
   ```sh
   $ mkdir /home/admin/rust
   $ cd /home/admin/rust
-  $ git clone --branch v0.9.4 https://github.com/romanz/electrs.git
+  $ git clone --branch v0.9.6 https://github.com/romanz/electrs.git
   $ cd electrs
   ```
 
@@ -108,7 +108,7 @@ We get the latest release of the Electrs source code, verify it, compile it to a
 
   ```sh
   $ curl https://romanzey.de/pgp.txt | gpg --import
-  $ git verify-tag v0.9.4
+  $ git verify-tag v0.9.6
   > gpg: Good signature from "Roman Zeyde <me@romanzey.de>" [unknown]
   > gpg: WARNING: This key is not certified with a trusted signature!
   > gpg:          There is no indication that the signature belongs to the owner.
@@ -432,13 +432,13 @@ Make sure to check the [release notes](https://github.com/romanz/electrs/blob/ma
   ```sh
   $ cd /home/admin/rust/electrs
 
-  # update the local source code and show the latest release tag (example: v9.9.9)
+  # update the local source code and show the latest release tag (example: v0.9.6)
   $ git fetch
-  $ git describe --tags --abbrev=0
-  > v9.9.9
+  $ git tag | sort --version-sort | tail -n 1
+  > v0.9.6
 
-  # check out the most recent release (replace v9.9.9 with the actual version)
-  $ git checkout v9.9.9
+  # check out the most recent release (replace v0.9.6 with the actual version)
+  $ git checkout v0.9.6
 
   # Compile the source code
   $ cargo clean


### PR DESCRIPTION
#### What

Bump Electrs version to v0.9.6 and update command to fetch latest release tag for upgrade guide.

### Why

Resolves #951. Fixes #970.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix
