### PR TITLE
add instructions to create and autoload bitcoind wallet

### DIFF
--- a/guide/bonus/bitcoin/electrum-personal-server.md
+++ b/guide/bonus/bitcoin/electrum-personal-server.md
@@ -119,6 +119,23 @@ Electrum Personal Server uses the Bitcoin Core wallet with "watch-only" addresse
   ```
 
   ![Install Electrum Personal Server with Python Pip](../../../images/60_eps_pip_install.png)
+  
+### Setup default wallet with `bitcoind` and set it to autoload on daemon start
+eps needs a "dummy" wallet configured in bitcoind to correctly scan for transactions.
+Create a basic wallet with
+```
+$ bitcoin-cli createwallet "default" "true" "true" "" "true"
+```
+and then add directive to autoload it into `bitcoin.conf`: 
+```
+$ nano ~/.bitcoin/bitcoin.conf
+```
+following can be placed after the `# Connections` stanza
+```
+# Default wallet
+wallet=/data/bitcoin/default
+```
+The default wallet will be automatically loaded after creation, and the autoload directive will take care of loading it at each restart.
 
 ### First start
 The Electrum Personal Server scripts are installed in the directory `/home/bitcoin/.local/bin/`. Unfortunately, in Raspberry Pi OS this directory is not in the system path, so the full path needs to be specified when calling these scripts. Alternatively, just [add this directory to your $PATH environment variable](https://unix.stackexchange.com/questions/26047/how-to-correctly-add-a-path-to-path){:target="_blank"}, but it's not necessary in this guide.
@@ -171,7 +188,9 @@ If everything works as expected, we will now automate the start of Electrum Pers
   `exit`
 
 * As "admin", set up the systemd unit for automatic start on boot, save and exit
-  `$ sudo nano /etc/systemd/system/eps.service`
+  ```
+  $ sudo nano /etc/systemd/system/eps.service
+  ```
 
 ```ini
 [Unit]


### PR DESCRIPTION
#### What

Instructions to create and autoload a dummy default wallet within bitcoind, missing which eps will not load.

### Why

To make eps start

#### How

Elite skills

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x ] simple bug fix

Fixes # (link issue) https://t.me/raspibolt/9452

#### Test & maintenance

Just did this on my fresh install as I encountered this problem, no further testing and maintenance are expected