### PR TITLE
System overview: Get running version of BTC RPC Explorer and RTL from `npm` not `git`

### DIFF
--- a/resources/20-raspibolt-welcome
+++ b/resources/20-raspibolt-welcome
@@ -415,7 +415,7 @@ if [ -z "${btcrpcexplorer_running##*inactive*}" ]; then
   btcrpcexplorerversion_color="${color_red}"
 else
   btcrpcexplorer_running="up"
-  btcrpcexplorerpi=$(git --git-dir /home/btcrpcexplorer/btc-rpc-explorer/.git describe --tags)
+  btcrpcexplorerpi=v$(cd /home/btcrpcexplorer/btc-rpc-explorer; npm version | grep -oP "'btc-rpc-explorer': '\K(.*)(?=')")
   if [ "$btcrpcexplorerpi" = "$btcrpcexplorergit" ]; then
     btcrpcexplorerversion="$btcrpcexplorerpi"
     btcrpcexplorerversion_color="${color_green}"
@@ -440,7 +440,7 @@ if [ -z "${rtl_running##*inactive*}" ]; then
   rtlversion_color="${color_red}"
 else
   rtl_running="up"
-  rtlpi=$(git --git-dir /home/rtl/RTL/.git describe --tags)
+  rtlpi=v$(cd /home/rtl/RTL; npm version | grep -oP "rtl: '\K(.*)(?=-beta')")
   if [ "$rtlpi" = "$rtlgit" ]; then
     rtlversion="$rtlpi"
     rtlversion_color="${color_green}"


### PR DESCRIPTION
#### What

Get current local installed / running BTC RPC Explorer and RTL version info from `npm` not `git`.

### Why

1) `git fetch` does not mean it's actually installed (`npm install`) and running;
2) `git describe tags` will not always return latest version.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix