### PR TITLE
Bump versions and update instructions to get latest release tag from `git` (RTL, charge-lnd, BoS)

### DIFF
--- a/guide/bonus/lightning/balance-of-satoshis.md
+++ b/guide/bonus/lightning/balance-of-satoshis.md
@@ -102,13 +102,13 @@ Table of contents
 * Find the most recent tag and verify the signature. Add the `--tags` option to select even a lightweight/non-annotated tag. Add the `--abbrev=0` option to remove any long-format tag names.
 
   ```sh
-  $ git describe --tags --abbrev=0
-  > v11.14.0
-  $ git verify-tag v11.14.0
-  > gpg: Signature made Tue 07 Dec 2021 03:57:11 GMT
-  > gpg:                using RSA key DE23E73BFA8A0AD5587D2FCDE80D2F3F311FD87E
+  $ git tag | sort --version-sort | tail -n 1
+  > v12.4.1
+  $ git verify-tag v12.4.1
   > gpg: Good signature from "Alex Bosworth <alex.bosworth@gmail.com>" [unknown]
-  > [...]
+  > gpg: WARNING: This key is not certified with a trusted signature!
+  > gpg:          There is no indication that the signature belongs to the owner.
+  > Primary key fingerprint: DE23 E73B FA8A 0AD5 587D  2FCD E80D 2F3F 311F D87E
   ```
 
 * Install Balance of Satoshis locally
@@ -122,7 +122,7 @@ Table of contents
 
   ```sh
   $ bos -V
-  > v11.14.0
+  > v12.4.1
   ```
 
 ---
@@ -137,7 +137,7 @@ To use Balance of Satoshis, we will use the "bos" user.
 
   ```sh
   $ bos help
-  > bos 11.14.0
+  > bos 12.4.1
   >
   > USAGE
   >
@@ -153,7 +153,7 @@ To use Balance of Satoshis, we will use the "bos" user.
 
   ```sh
   $ bos help rebalance
-  > bos 11.14.0
+  > bos 12.4.1
   >
   > USAGE
   >
@@ -271,11 +271,11 @@ You can also join the Balance of Satoshis Telegram group to get support: [https:
   $ cd balanceofsatoshis
   ```
 
-* Check what version you are using currently (e.g. here v11.14.0)
+* Check what version you are using currently (e.g. here v12.4.1)
 
   ```sh
   $ bos -V
-  > 11.14.0
+  > 12.4.1
   ```
 
 * Update the local repository by downloading the new commits from the source repository and check if a new tag/version is available (e.g. here v99.99.9)
@@ -289,8 +289,8 @@ You can also join the Balance of Satoshis Telegram group to get support: [https:
 * Find the most recent tag. Add the `--tags` option to select even a lightweight/non-annotated tag. Add the `--abbrev=0` option to remove any long-format tag names.
 
   ```sh
-  $ git describe --tags --abbrev=0
-  > v11.14.0
+  $ git tag | sort --version-sort | tail -n 1
+  > v12.4.1
   ```
 
 * Remove any potential uncommited changes to your local branch to avoid issues when checking out the new tag
@@ -314,10 +314,11 @@ You can also join the Balance of Satoshis Telegram group to get support: [https:
 
   ```sh
   $ git verify-tag v99.99.9
-  > gpg: Signature made Tue 07 Dec 2021 03:57:11 GMT
-  > gpg:                using RSA key DE23E73BFA8A0AD5587D2FCDE80D2F3F311FD87E
-  > gpg: Good signature from "Alex Bosworth <alex.bosworth@gmail.com>" [unknown]
   > [...]
+  > gpg: Good signature from "Alex Bosworth <alex.bosworth@gmail.com>" [unknown]
+  > gpg: WARNING: This key is not certified with a trusted signature!
+  > gpg:          There is no indication that the signature belongs to the owner.
+  > Primary key fingerprint: DE23 E73B FA8A 0AD5 587D  2FCD E80D 2F3F 311F D8
   ```
 
 * Install the new version and check this it has been installed properly

--- a/guide/bonus/lightning/charge-lnd.md
+++ b/guide/bonus/lightning/charge-lnd.md
@@ -306,14 +306,14 @@ If you need to check the log files:
   $ cd charge-lnd
   $ pip3 show charge-lnd
   > Name: charge-lnd
-  > Version: 0.2.8
+  > Version: 0.2.10
   ```
 
 * Fetch the latest version and install it (*e.g.* v9.9.9)
 
   ```sh
   $ git fetch
-  $ git describe --tags --abbrev=0
+  $ git tag | sort --version-sort | tail -n 1
   > v9.9.9
   $ git reset --hard HEAD
   > HEAD is now at [...]

--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -102,14 +102,12 @@ We do not want to run Ride the Lightning alongside bitcoind and lnd because of s
   $ git clone https://github.com/Ride-The-Lightning/RTL.git
   $ cd RTL
 
-  $ git describe --tags --abbrev=0
-  > v0.11.2
+  $ git tag | sort --version-sort | tail -n 1
+  > v0.12.2
 
-  $ git checkout v0.11.2
+  $ git checkout v0.12.2
 
-  $ git verify-tag v0.11.2
-  > gpg: Signature made Fri 03 Sep 2021 02:59:24 BST
-  > gpg:                using RSA key 3E9BD4436C288039CA827A9200C9E2BC2E45666F
+  $ git verify-tag v0.12.2
   > gpg: Good signature from "saubyk (added uid) <39208279+saubyk@users.noreply.github.com>" [unknown]
   > gpg:                 aka "Suheb <39208279+saubyk@users.noreply.github.com>" [unknown]
   > gpg: WARNING: This key is not certified with a trusted signature!
@@ -284,14 +282,14 @@ Make sure to read the release notes first.
   $ sudo su - rtl
   ```
 
-* Fetch the latest GitHub repository information, display the latest release tag (`v9.99.9` in this example), and update:
+* Fetch the latest GitHub repository information, display the latest release tag (`v0.12.2` in this example), and update:
 
   ```sh
   $ cd /home/rtl/RTL
   $ git fetch
-  $ git describe --tags --abbrev=0
-  $ git checkout v9.99.9
-  $ git verify-tag v9.99.9
+  $ git tag | sort --version-sort | tail -n 1
+  $ git checkout v0.12.2
+  $ git verify-tag v0.12.2
   $ npm install --only=prod
   $ exit
   ```


### PR DESCRIPTION
#### What

Bump latest version fo RTL, charge-lnd and BoS and update commands to get latest release tags for upgrades.

Also updated sample `git verify-tag` outputs. Signature date/time will change witch each versions, checking fingerprint is more important.

### Why

See #987, same as was done there for Electrs.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix

P.S. Could we write some bot that automatically opens version bump PRs?