### PR TITLE
Removed dark mode configuration lines in ThunderHub as it is default

### DIFF
--- a/guide/bonus/lightning/thunderhub.md
+++ b/guide/bonus/lightning/thunderhub.md
@@ -132,11 +132,6 @@ We are going to install Thunderhub in the home directory since it doesn't need t
   PORT=3010
 
   # -----------
-  # Interface Configs
-  # -----------
-  THEME='dark'
-
-  # -----------
   # Account Configs
   # -----------
   ACCOUNT_CONFIG_PATH='/home/thunderhub/thunderhub/thubConfig.yaml'


### PR DESCRIPTION
#### What

* Removed dark mode configuration lines in ThunderHub guide

### Why

Dark mode is the default value.

Source: https://docs.thunderhub.io/setup/#config

> THEME = 'dark' | 'light' | 'night' # Default: 'dark'

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes #1002 
