### PR TITLE
Two small bug fixes for Homer and Sparrow

### DIFF
--- a/guide/bitcoin/desktop-wallet.md
+++ b/guide/bitcoin/desktop-wallet.md
@@ -137,7 +137,7 @@ you can obtain it again by running the following command with "admin" on your no
 ### Sparrow configuration
 
 * Open Sparrow
-* Navigate to the server configuration page by hitting `Ctrl`+`P`, or  `Cmd`+`P` on OSX, then click on "Server"
+* Navigate to the server configuration page by hitting `Ctrl`+`P`, or  `Cmd`+`,` on OSX, then click on "Server"
 * Click on the "Private Electrum" tab. If you've already have an existing clearnet connection, click on "Edit Existing Connection".
 * On the "URL" line, paste your Tor hidden service connection address (e.g. "abcd...1234.onion") in the first box and `50002` in the second box
 * Enable SSL by clicking on the slider
@@ -178,7 +178,7 @@ Here, we'll use the Tor Browser and port 9150 as it is easier to set up on Windo
 ### Wallet configuration
 
 * Open Sparrow
-* Navigate to the server configuration page by hitting `Ctrl`+`P`, or  `Cmd`+`P` on OSX, then click on "Server"
+* Navigate to the server configuration page by hitting `Ctrl`+`P`, or  `Cmd`+`,` on OSX, then click on "Server"
 * Click on the "Private Electrum" tab. If you've already have an existing clearnet connection, click on "Edit Existing Connection".
 * Enable the Tor proxy by clicking on the "Use proxy" slider
 * On the "Proxy URL" line, paste `127.0.0.1` in the first box and either `9150` or `9050` in the second box depending if you run the Tor Browser or Tor as a background service.

--- a/guide/bonus/raspberry-pi/homer.md
+++ b/guide/bonus/raspberry-pi/homer.md
@@ -694,6 +694,7 @@ Updating to a [new release](https://github.com/bastienwirtz/homer/releases){:tar
         # [...]
   
   #}
+  ```
 
 * Test and reload nginx configuration
 


### PR DESCRIPTION
#### What

* Sparrow: Fixes OSX shortcut to open settings
  * as suggested by @craigraw https://github.com/raspibolt/raspibolt/pull/967#issuecomment-1113180274)

* Homer: Adds missing code block closing quotes to fix display issue

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Check that the display issue with Homer is fixed and that the OSX command is OK.
