### PR TITLE
Grant mempool mysql access only to localhost and use random password

### DIFF
--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -117,7 +117,7 @@ For improved security, we create the new user "mempool" that will run the Mempoo
   ```sql
   MDB$ create database mempool;
   > Query OK, 1 row affected (0.001 sec)
-  MDB$ grant all privileges on mempool.* to 'mempool'@'%' identified by 'mempool';
+  MDB$ grant all privileges on mempool.* to 'mempool'@'localhost' identified by 'mempool';
   > Query OK, 0 rows affected (0.012 sec)
   MDB$ exit
   ```

--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -102,7 +102,14 @@ For improved security, we create the new user "mempool" that will run the Mempoo
   $ sudo apt update
   $ sudo apt install mariadb-server mariadb-client
   ```
-  
+
+* Generate random password for "mempool" MariaDB user. This password will be needed for one command and then in config file below. Let's call it "Password[M]".
+
+  ```sh
+  $ gpg --gen-random --armor 1 16
+  > G53Lp+V7JYmo9JpVa72bGw==
+  ```
+
 * Now, open the MariaDB shell. 
 
   ```sh
@@ -112,12 +119,12 @@ For improved security, we create the new user "mempool" that will run the Mempoo
   > MariaDB [(none)]>
   ```
 
-* Enter the following commands in the shell and exit. The instructions to enter in the MariaDB shell with start with "MDB$"
+* Enter the following commands in the shell and exit. The instructions to enter in the MariaDB shell with start with "MDB$". Change "Password[M]" to the random password generated above.
 
   ```sql
   MDB$ create database mempool;
   > Query OK, 1 row affected (0.001 sec)
-  MDB$ grant all privileges on mempool.* to 'mempool'@'localhost' identified by 'mempool';
+  MDB$ grant all privileges on mempool.* to 'mempool'@'localhost' identified by 'Password[M]';
   > Query OK, 0 rows affected (0.012 sec)
   MDB$ exit
   ```
@@ -139,7 +146,7 @@ For improved security, we create the new user "mempool" that will run the Mempoo
   $ nano mempool-config.json
   ```
 
-* Paste the following lines. In the CORE_RPC section, replace the username and password with your username (e.g., "raspibolt") and password [B].
+* Paste the following lines. In the CORE_RPC section, replace the username and password with your username (e.g., "raspibolt") and password [B]. Change "Password[M]" to the random password generated above.
 
 
   ```sh
@@ -177,7 +184,7 @@ For improved security, we create the new user "mempool" that will run the Mempoo
       "HOST": "127.0.0.1",
       "PORT": 3306,
       "USERNAME": "mempool",
-      "PASSWORD": "mempool",
+      "PASSWORD": "Password[M]",
       "DATABASE": "mempool"
     },
     "SOCKS5PROXY": {


### PR DESCRIPTION
#### What

Allow `mempool` mysql (mariadb) user access only from localhost. It is good common security practice. Does not change much in practice with default mariadb config, as only localhost access is allowed to server, but can change, if for some reason remote (for example, LAN) access is enabled later.

Also using hardcoded "mempool" as a password is not great, but probably not so important right now, as mempool is the only service in RaspiBolt guides that users mysql. But better would be to generate random password. I can add a commit on top of this that changes that too, but will complicate guide little bit.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix
