### PR TITLE
Ignore RC pre-releases for RTL

### DIFF
--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -287,6 +287,7 @@ Make sure to read the release notes first.
   ```sh
   $ cd /home/rtl/RTL
   $ git fetch
+  $ git reset --hard
   $ git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1
   $ git checkout v0.12.3
   $ git verify-tag v0.12.3

--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -102,12 +102,12 @@ We do not want to run Ride the Lightning alongside bitcoind and lnd because of s
   $ git clone https://github.com/Ride-The-Lightning/RTL.git
   $ cd RTL
 
-  $ git tag | sort --version-sort | tail -n 1
-  > v0.12.2
+  $ git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1
+  > v0.12.3
 
-  $ git checkout v0.12.2
+  $ git checkout v0.12.3
 
-  $ git verify-tag v0.12.2
+  $ git verify-tag v0.12.3
   > gpg: Good signature from "saubyk (added uid) <39208279+saubyk@users.noreply.github.com>" [unknown]
   > gpg:                 aka "Suheb <39208279+saubyk@users.noreply.github.com>" [unknown]
   > gpg: WARNING: This key is not certified with a trusted signature!
@@ -282,14 +282,14 @@ Make sure to read the release notes first.
   $ sudo su - rtl
   ```
 
-* Fetch the latest GitHub repository information, display the latest release tag (`v0.12.2` in this example), and update:
+* Fetch the latest GitHub repository information, display the latest release tag, ignoring release cadidates (`v0.12.3` in this example), and update:
 
   ```sh
   $ cd /home/rtl/RTL
   $ git fetch
-  $ git tag | sort --version-sort | tail -n 1
-  $ git checkout v0.12.2
-  $ git verify-tag v0.12.2
+  $ git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1
+  $ git checkout v0.12.3
+  $ git verify-tag v0.12.3
   $ npm install --only=prod
   $ exit
   ```

--- a/resources/20-raspibolt-welcome
+++ b/resources/20-raspibolt-welcome
@@ -143,7 +143,7 @@ if [ "${gitupdate}" -eq "1" ]; then
   # Electrs, RPC Explorer and RTL dont have a latest release, just tags
   electrsgit=$(curl -s https://api.github.com/repos/romanz/electrs/tags | jq -r '.[0].name')
   btcrpcexplorergit=$(curl -s https://api.github.com/repos/janoside/btc-rpc-explorer/tags | jq -r '.[0].name')
-  rtlgit=$(curl -s https://api.github.com/repos/Ride-The-Lightning/RTL/tags | jq -r '.[0].name')
+  rtlgit=$(curl -s https://api.github.com/repos/Ride-The-Lightning/RTL/tags | jq -r '.[] | select(.name | test("rc") | not) | .name' | head -n 1)
   # write to file TODO: convert to JSON for sanity
   printf "%s\n%s\n%s\n%s\n%s\n" "${btcgit}" "${lndgit}" "${electrsgit}" "${btcrpcexplorergit}" "${rtlgit}" > "${gitstatusfile}"
 else
@@ -167,8 +167,8 @@ else
   if [ -z "$btcrpcexplorergit" ]; then
     btcrpcexplorergit=$(curl -s https://api.github.com/repos/janoside/btc-rpc-explorer/tags | jq -r '.[0].name')
   fi
-    if [ -z "$rtlgit" ]; then
-    rtlgit=$(curl -s https://api.github.com/repos/Ride-The-Lightning/RTL/tags | jq -r '.[0].name')
+  if [ -z "$rtlgit" ]; then
+    rtlgit=$(curl -s https://api.github.com/repos/Ride-The-Lightning/RTL/tags | jq -r '.[] | select(.name | test("rc") | not) | .name' | head -n 1)
   fi
   printf "%s\n%s\n%s\n%s\n%s\n" "${btcgit}" "${lndgit}" "${electrsgit}" "${btcrpcexplorergit}" "${rtlgit}" > "${gitstatusfile}"
 fi


### PR DESCRIPTION
#### What

RTL has tags also for RC (release candidate) pre-releases, you want to ignore them when checking for latest version.

Currently, without this change, will think v0.12.4-rc1 is the latest, after - v0.12.3.

#### How

Ignore git tags that contain "rc".

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix

#### Test & maintenance

Just check before / after bash oneliner result.
