### PR TITLE
Section for macOS users on remote SSH through Tor

### DIFF
--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -132,11 +132,12 @@ A few examples:
   ```sh
   $ torify ssh admin@abcdefg..............xyz.onion
   ```
+
   ```sh
   $ torsocks ssh admin@abcdefg..............xyz.onion
   ```
 
-  * **macOS**: Using `torify` or `torsocks` may not work due to Apple's *System Integrity Protection (SIP)* which will deny access to `/usr/bin/ssh`.
+* **macOS**: Using `torify` or `torsocks` may not work due to Apple's *System Integrity Protection (SIP)* which will deny access to `/usr/bin/ssh`.
 
   To work around this, first make sure Tor is installed and running on your Mac:
 
@@ -150,7 +151,7 @@ A few examples:
   $ ssh -o "ProxyCommand nc -X 5 -x 127.0.0.1:9050 %h %p" admin@abcdefg..............xyz.onion
   ```
 
-  For a more permanent solution, add these six lines below to your local SSH config file. Choose any Hostnickname you want, save and exit.
+  For a more permanent solution, add these six lines below to your local SSH config file. Choose any HOSTNICKNAME you want, save and exit.
 
   ```sh
   $ sudo nano .ssh/config

--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -144,15 +144,20 @@ A few examples:
   $ brew install tor && brew services start tor
   ```
 
-  Add the six lines below to your local SSH config file. Choose any Hostnickname you want, save and exit.
+  You can SSH to your Pi "out of the box" with the following proxy command:
+
+  ```sh
+  $ ssh -o "ProxyCommand nc -X 5 -x 127.0.0.1:9050 %h %p" admin@abcdefg..............xyz.onion
+  ```
+
+  For a more permanent solution, add these six lines below to your local SSH config file. Choose any Hostnickname you want, save and exit.
 
   ```sh
   $ sudo nano .ssh/config
   ```
 
   ```sh
-  # Config for Raspibolt
-  Host raspibolt-tor
+  Host HOSTNICKNAME
     Hostname abcdefg..............xyz.onion
     User admin
     Port 22
@@ -166,10 +171,10 @@ A few examples:
   $ brew services restart tor
   ```
 
-  You should now be able to SSH to your Raspibolt through Tor
+  You should now be able to SSH to your Pi with
 
   ```sh
-  $ ssh raspibolt-tor
+  $ ssh HOSTNICKNAME
   ```
 
 <br /><br />

--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -126,7 +126,7 @@ A few examples:
 
   * **Note:** If you are using PuTTy and fail to connect to your Pi by setting port 9050 in the PuTTy proxy settings, try setting port 9150 instead. When Tor runs as an installed application instead of a background process it uses port 9150.
 
-* **MacOS and Linux**: use `torify` or `torsocks`.
+* **Linux**: use `torify` or `torsocks`.
   Both work similarly; just use whatever you have available:
 
   ```sh
@@ -134,6 +134,42 @@ A few examples:
   ```
   ```sh
   $ torsocks ssh admin@abcdefg..............xyz.onion
+  ```
+
+  * **macOS**: Using `torify` or `torsocks` may not work due to Apple's *System Integrity Protection (SIP)* which will deny access to `/usr/bin/ssh`.
+
+  To work around this, first make sure Tor is installed and running on your Mac:
+
+  ```sh
+  $ brew install tor && brew services start tor
+  ```
+
+  Add the six lines below to your local SSH config file. Choose any Hostnickname you want, save and exit.
+
+  ```sh
+  $ sudo nano .ssh/config
+  ```
+
+  ```sh
+  # Config for Raspibolt
+  Host raspibolt-tor
+    Hostname abcdefg..............xyz.onion
+    User admin
+    Port 22
+    CheckHostIP no
+    ProxyCommand /usr/bin/nc -x localhost:9050 %h %p
+  ```
+
+  Restart Tor
+
+  ```sh
+  $ brew services restart tor
+  ```
+
+  You should now be able to SSH to your Raspibolt through Tor
+
+  ```sh
+  $ ssh raspibolt-tor
   ```
 
 <br /><br />


### PR DESCRIPTION
#### What

Added a seperate section for macOS Users on how to setup remote SSH through Tor.

#### Why

Using `torify` or `torsocks` as suggested will cause issues with _System Integrity Protection_.

```text
ERROR: /usr/local/bin/ssh is located in a directory protected by Apple's System Integrity Protection.
```

Simply turning SIP off is dangerous and not recommended, even though it's probably the fastest solution to this.

#### How

The solution below simply adds a SSH config file with a proxy command. Once set up, one can conveniently SSH to the Pi with `ssh HOSTNICKNAME`.

#### Scope

- [x] significant change to core configuration (?)
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Tested on macOS 12.4.

I am unsure from what version of macOS onwards this issue occurs, but some users on StackExchange have suggested 10.11 i.e. "El Capitan" which should affect almost every macOS user.