### PR TITLE
Fixed permission issue in microSD bonus guide

### DIFF
--- a/guide/bonus/raspberry-pi/boot-from-microsd-card.md
+++ b/guide/bonus/raspberry-pi/boot-from-microsd-card.md
@@ -123,6 +123,7 @@ The external drive is then attached to the file system and becomes available as 
 
   ```sh
   $ sudo mkdir /data
+  $ sudo chown admin:admin /data
   $ sudo chattr +i /data
   ```
 


### PR DESCRIPTION
#### What

Added `chown admin:admin /data` which is included in the default configuration guide, but was missing in the _Boot from microSD_ bonus guide resulting in permission denied when trying to create the bitcoin directory.

`mkdir: cannot create directory '/data/bitcoin': Permission denied`

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes https://github.com/raspibolt/raspibolt/issues/1038
