### PR TITLE
Replaces outdated LN+ watchtower address with the new one

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -568,6 +568,18 @@ It's good practice to add a few watchtowers, just to be on the safe side.
   ```
 * Check out this [list of altruistic public watchtowers](https://github.com/openoms/lightning-node-management/issues/4){:target="_blank"} maintained by Openoms, and add a few more.
 
+* If you want to list your towers
+
+  ```sh
+  $ lncli wtclient towers
+  ```
+
+* If you want to deactivate an active tower
+
+  ```sh
+  $ lncli wtclient remove <pubkey>
+  ```
+
 ### More commands
 
 A quick reference with common commands to play around with:

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -544,7 +544,7 @@ It's good practice to add a few watchtowers, just to be on the safe side.
 
   ```sh
   $ sudo su - lnd
-  $ lncli wtclient add 0301135932e89600b3582513c648d46213dc425c7666e3380faa7dbb51f7e6a3d6@tower4excc3jdaoxcqzbw7gzipoknzqn3dbnw2kfdfhpvvbxagrzmfad.onion:9911
+  $ lncli wtclient add 023bad37e5795654cecc69b43599da8bd5789ac633c098253f60494bde602b60bf@iiu4epqzm6cydqhezueenccjlyzrqeruntlzbx47mlmdgfwgtrll66qd.onion:9911
   ```
 
 * Check if the watchtower is active
@@ -554,15 +554,15 @@ It's good practice to add a few watchtowers, just to be on the safe side.
   {
       "towers": [
           {
-              "pubkey": "0301135932e89600b3582513c648d46213dc425c7666e3380faa7dbb51f7e6a3d6",
+              "pubkey": "023bad37e5795654cecc69b43599da8bd5789ac633c098253f60494bde602b60bf",
               "addresses": [
-                  "tower4excc3jdaoxcqzbw7gzipoknzqn3dbnw2kfdfhpvvbxagrzmfad.onion:9911"
+                  "iiu4epqzm6cydqhezueenccjlyzrqeruntlzbx47mlmdgfwgtrll66qd.onion:9911"
               ],
               "active_session_candidate": true,
               "num_sessions": 0,
               "sessions": [
               ]
-          }
+          },
       ]
   }
   ```

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -549,7 +549,7 @@ It's good practice to add a few watchtowers, just to be on the safe side.
 
 * Check if the watchtower is active
 
-  ```json
+  ```sh
   $ lncli wtclient towers
   {
       "towers": [


### PR DESCRIPTION
#### What

Existing LN+ watchtower is outdated, see their announcement on their website (https://lightningnetwork.plus/watchtower):
![image](https://user-images.githubusercontent.com/86242283/178156181-1b546661-d610-49bf-b3e4-06f3e3fb96db.png)

The PR replaces the old address with the new recommended one (displayed furtther down the webpage: https://lightningnetwork.plus/watchtower

![image](https://user-images.githubusercontent.com/86242283/178156238-115249d8-27de-41fd-bd1c-4d1591e6ee9d.png)

The issue was flagged here: https://t.me/raspibolt/11758

#### Scope

- [ ] significant change to core configuration
- [x] minor change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Test the new watchtower

#### Animated GIF (optional)
![WT](https://media.giphy.com/media/Y8S9D9drlYeTiZEM4X/giphy-downsized.gif)
