### PR TITLE
Remove outdated "index_lookup_limit" from config

### DIFF
--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -159,7 +159,6 @@ We get the latest release of the Electrs source code, verify it, compile it to a
   # Electrs settings
   electrum_rpc_addr = "127.0.0.1:50001"
   db_dir = "/data/electrs/db"
-  index_lookup_limit = 1000
 
   # Logging
   log_filters = "INFO"


### PR DESCRIPTION
#### What/why/how

The Electrs configuration file option `index_lookup_limit` is now disabled by default because not useful for operators using Electrs for themselves only. 

See #888 for more detailed explanations and useful links.

#### Scope

- [ ] significant change to core configuration
- [x] minor change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

Fixes #888 

#### Test & maintenance

Run Electrs with the deleted conf option

#### Animated GIF (optional)
![no_limit](https://media.giphy.com/media/xT9DPOYvQOOefGvxde/giphy.gif)
