### PR TITLE
Adding the lnd stop command in systemd unit file

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -342,6 +342,7 @@ Now, let's set up LND to start automatically on system startup.
   # Service execution
   ###################
   ExecStart=/usr/local/bin/lnd
+  ExecStop=/usr/local/bin/lncli stop
 
   # Process management
   ####################


### PR DESCRIPTION
#### What

Without this command, an incorrect stop occurs - systemd sends a kill signal, which is not processed correctly by LND - part of the services inside LND stops, but the process itself continues to work. Then systemd sends signal `9`, which kills the process.

```
Jul 21 09:45:35 electrs lnd[20686]: 2022-07-21 09:45:35.719 [INF] WTCL: (legacy) Client stats: tasks(received=0 accepted=0 ineligible=0) sessions(acquired=0 exhausted=0)
Jul 21 09:46:35 electrs lnd[20686]: 2022-07-21 09:46:35.719 [INF] WTCL: (anchor) Client stats: tasks(received=0 accepted=0 ineligible=0) sessions(acquired=0 exhausted=0)
Jul 21 09:46:35 electrs lnd[20686]: 2022-07-21 09:46:35.719 [INF] WTCL: (legacy) Client stats: tasks(received=0 accepted=0 ineligible=0) sessions(acquired=0 exhausted=0)
Jul 21 09:47:17 electrs systemd[1]: lnd.service: State 'stop-sigterm' timed out. Killing.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Killing process 20686 (lnd) with signal SIGKILL.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Killing process 20687 (lnd) with signal SIGKILL.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Killing process 20688 (n/a) with signal SIGKILL.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Killing process 20691 (lnd) with signal SIGKILL.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Killing process 20692 (lnd) with signal SIGKILL.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Killing process 20693 (n/a) with signal SIGKILL.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Killing process 20695 (n/a) with signal SIGKILL.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Killing process 24281 (n/a) with signal SIGKILL.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Killing process 60287 (lnd) with signal SIGKILL.
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Main process exited, code=killed, status=9/KILL
Jul 21 09:47:17 electrs systemd[1]: lnd.service: Failed with result 'timeout'.
Jul 21 09:47:17 electrs systemd[1]: Stopped LND Lightning Network Daemon.
```

### Why

In this case (kill -9 LND_PID), data loss (for example, channels) may occur, which will lead to the loss of funds.

#### How

Added ExecStop command to systemd unit file in docs
After patch a stopping looks like this:

```
Jul 21 11:36:19 electrs lnd[981]: 2022-07-21 11:36:19.649 [INF] RPCS: Stopping RouterRPC Sub-RPC Server
Jul 21 11:36:19 electrs lnd[981]: 2022-07-21 11:36:19.649 [INF] RPCS: Stopping WatchtowerRPC Sub-RPC Server
Jul 21 11:36:19 electrs lnd[981]: 2022-07-21 11:36:19.649 [INF] RPCS: Stopping WalletKitRPC Sub-RPC Server
Jul 21 11:36:19 electrs lnd[981]: 2022-07-21 11:36:19.649 [INF] RPCS: Stopping AutopilotRPC Sub-RPC Server
Jul 21 11:36:19 electrs lnd[981]: 2022-07-21 11:36:19.649 [INF] RPCS: Stopping NeutrinoKitRPC Sub-RPC Server
Jul 21 11:36:19 electrs lnd[981]: 2022-07-21 11:36:19.649 [INF] TORC: Stopping tor controller
Jul 21 11:36:19 electrs lnd[981]: 2022-07-21 11:36:19.670 [INF] LTND: Shutdown complete
Jul 21 11:36:19 electrs systemd[1]: lnd.service: Succeeded.
Jul 21 11:36:19 electrs systemd[1]: Stopped LND Lightning Network Daemon.
Jul 21 11:36:19 electrs systemd[1]: lnd.service: Consumed 46.946s CPU time.
```

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix