### PR TITLE
[FEATURE REQ] Add tor feature + comment ssh hidden service in privacy section

### DIFF
--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -78,6 +78,12 @@ We need to enable Tor to accept instructions through its control port, with the 
   $ sudo systemctl reload tor
   ```
 
+* Check the systemd journal to see Tor real time updates output logs.
+  
+  ```sh
+  $ sudo journalctl -f -u tor@default
+  ```
+
 Not all network traffic is routed over the Tor network.
 But we now have the base to configure sensitive applications to use it.
 
@@ -99,7 +105,7 @@ This makes "calling home" very easy, without the need to configure anything on y
 
   ```sh
   ############### This section is just for location-hidden services ###
-
+  # Hidden Service SSH server
   HiddenServiceDir /var/lib/tor/hidden_service_sshd/
   HiddenServiceVersion 3
   HiddenServicePort 22 127.0.0.1:22


### PR DESCRIPTION
#### What

- Added monitoring tor logs
- Standardized comment for ssh hidden service torrc config

### Why

Improve tor monitoring to detect possible errors in the network

#### How

adding `sudo journalctl -f -u tor@default` command
adding `# Hidden Service SSH server` comment in torrc file

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

The changes were tested by myself.
