### PR TITLE
Make a Lightning payment. Fix LNURL pay section with lncli command 

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -518,7 +518,7 @@ Just grab the whole URI above the big QR code and use it as follows (we will use
   $ lncli listchannels
   ```
 
-* **Make a Lightning payment**. TBy default, these work with invoices, so when you buy something or want to send money, you need to get an invoice first. However, you can also pay without requesting an invoice as long the receiving node supports the keysend or amp feature!
+* **Make a Lightning payment**. By default, these work with invoices, so when you buy something or want to send money, you need to get an invoice first. However, you can also pay without requesting an invoice as long the receiving node supports the keysend or amp feature!
   
   To try, why not send me a single satoshi! You simply need to input my node pukey [`Stadicus node`](https://amboss.space/node/02acd93e3352fd59066ca3f23e8865de1926301e8be03c6a52f0f7e43533fe9888){:target="_blank"}, the amount in satoshis and add the –keysend flag. 
 

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -519,6 +519,9 @@ Just grab the whole URI above the big QR code and use it as follows (we will use
   ```
 
 * **Make a Lightning payment**. These work with invoices, so everytime you buy something or want to send money, you need to get an invoice first.
+Or you can pay directly another node.
+LND not support LNURL so you can pay an invoice using a mobile wallet that support LNURL
+  
   To try, why not send me a single satoshi to view my Twitter profile?
 
   * Click on this Tippin.me link: <https://tippin.me/@Stadicus3000>
@@ -526,8 +529,14 @@ Just grab the whole URI above the big QR code and use it as follows (we will use
   * Pay me 1 satoshi (~ $0.0001) 🤑
 
     ```sh
-    * lncli payinvoice lnbc10n1pw......................gsj59
+    * lncli payinvoice lnurl..........
     ```
+  Or you can do it using lncli , [`Stadicus node`](https://amboss.space/node/02acd93e3352fd59066ca3f23e8865de1926301e8be03c6a52f0f7e43533fe9888){:target="_blank"} 
+
+    ```sh
+    * lncli sendpayment --dest 02acd93e3352fd59066ca3f23e8865de1926301e8be03c6a52f0f7e43533fe9888 --amt 1 --keysend
+    ```
+
 
 ### Adding watchtowers
 

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -518,20 +518,9 @@ Just grab the whole URI above the big QR code and use it as follows (we will use
   $ lncli listchannels
   ```
 
-* **Make a Lightning payment**. These work with invoices, so everytime you buy something or want to send money, you need to get an invoice first.
-Or you can pay directly another node.
-LND not support LNURL so you can pay an invoice using a mobile wallet that support LNURL
+* **Make a Lightning payment**. TBy default, these work with invoices, so when you buy something or want to send money, you need to get an invoice first. However, you can also pay without requesting an invoice as long the receiving node supports the keysend or amp feature!
   
-  To try, why not send me a single satoshi to view my Twitter profile?
-
-  * Click on this Tippin.me link: <https://tippin.me/@Stadicus3000>
-  * Click on "Copy request" to copy the invoice data
-  * Pay me 1 satoshi (~ $0.0001) 🤑
-
-    ```sh
-    * lncli payinvoice lnurl..........
-    ```
-  Or you can do it using lncli , [`Stadicus node`](https://amboss.space/node/02acd93e3352fd59066ca3f23e8865de1926301e8be03c6a52f0f7e43533fe9888){:target="_blank"} 
+  To try, why not send me a single satoshi! You simply need to input my node pukey [`Stadicus node`](https://amboss.space/node/02acd93e3352fd59066ca3f23e8865de1926301e8be03c6a52f0f7e43533fe9888){:target="_blank"}, the amount in satoshis and add the –keysend flag. 
 
     ```sh
     * lncli sendpayment --dest 02acd93e3352fd59066ca3f23e8865de1926301e8be03c6a52f0f7e43533fe9888 --amt 1 --keysend


### PR DESCRIPTION
Section "lightning->lightning-client ->Make a Lightning payment"
it's write to pay in  tippin.me.
But in these way you get a LNURL that not works in LND.

#### What

In the guide section, to try first LN invoice payment,  the link to  tippin me  gives an  LNURL .

### Why

LNURL not works in LND right now.

#### How

Write a better explanation and a cli command to pay the Stadicus node

#### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [ ] simple bug fix