### PR TITLE
Change sync-freelist to false in the lnd.conf

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -187,7 +187,6 @@ To improve the security of your wallet, check out these more advanced methods:
   gc-canceled-invoices-on-startup=true
   gc-canceled-invoices-on-the-fly=true
   ignore-historical-gossip-filters=1
-  sync-freelist=false
   stagger-initial-reconnect=true
   routing.strictgraphpruning=true
 

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -187,7 +187,7 @@ To improve the security of your wallet, check out these more advanced methods:
   gc-canceled-invoices-on-startup=true
   gc-canceled-invoices-on-the-fly=true
   ignore-historical-gossip-filters=1
-  sync-freelist=true
+  sync-freelist=false
   stagger-initial-reconnect=true
   routing.strictgraphpruning=true
 


### PR DESCRIPTION
The setting sync-freelist=true caused heavy bloating of the channel.db (several GB per day). Disabling this setting fixes this issue.

Related:
https://github.com/lightningnetwork/lnd/issues/6800
https://github.com/lightningnetwork/lnd/issues/6744
https://github.com/lightningnetwork/lnd/issues/6737
https://github.com/lightningnetwork/lnd/issues/6837#issuecomment-1218342468
