### PR TITLE
[UPDATE BONUS GUIDE] Minor update of the Fulcrum bonus guide

### DIFF
--- a/guide/bonus/bitcoin/fulcrum.md
+++ b/guide/bonus/bitcoin/fulcrum.md
@@ -367,7 +367,7 @@ Fulcrum will now index the whole Bitcoin blockchain so that it can provide all n
 
 DO NOT REBOOT OR STOP THE SERVICE DURING DB CREATION PROCESS. YOU MAY CORRUPT THE FILES - in case of that happening, start sync from scratch by deleting and recreating `fulcrum_db` folder.
 
-💡 Fulcrum must first fully index the blockchain and compact its database before you can connect to it with your wallets. This can take a few hours. Only proceed with the [Desktop Wallet Section](../../bitcoin/desktop-wallet.md) once Fulcrum is ready.
+💡 Fulcrum must first fully index the blockchain and compact its database before you can connect to it with your wallets. This can take up until ~3.5 - 4 days. Only proceed with the [Desktop Wallet Section](../../bitcoin/desktop-wallet.md) once Fulcrum is ready.
 
 💡 After the initial sync of Fulcrum, if you want to still use zram, you can return to the default zram config.
 

--- a/guide/bonus/bitcoin/fulcrum.md
+++ b/guide/bonus/bitcoin/fulcrum.md
@@ -113,7 +113,7 @@ $ sudo cat /proc/swaps
 Expected output:
 
 ```sh
-Filename                                Type                Size           Used    Priority
+Filename                               Type                 Size           Used    Priority
 /var/swap                              file                 102396         0       -2
 /dev/zram0                             partition            102396         0        5
 ```
@@ -231,6 +231,7 @@ $ sudo adduser fulcrum bitcoin
 $ sudo mkdir -p /data/fulcrum/fulcrum_db
 $ sudo chown -R fulcrum:fulcrum /data/fulcrum/
 ```
+
 * Create a symlink to /home/fulcrum/.fulcrum
 
 ```sh
@@ -265,7 +266,7 @@ $ nano /data/fulcrum/fulcrum.conf
 
 # Bitcoin Core settings
 bitcoind = 127.0.0.1:8332
-rpccookie= /home/bitcoin/.bitcoin/.cookie
+rpccookie = /home/bitcoin/.bitcoin/.cookie
 
 # Fulcrum server settings
 datadir = /data/fulcrum/fulcrum_db
@@ -273,7 +274,6 @@ cert = /data/fulcrum/cert.pem
 key = /data/fulcrum/key.pem
 ssl = 0.0.0.0:50002
 peering = false
-announce = false
 
 # RPi optimizations
 bitcoind_timeout = 600
@@ -286,7 +286,7 @@ db_max_open_files = 200
 fast-sync = 1024
 
 # 8GB RAM (comment the last two lines and uncomment the next)
-#db_max_open_files= 400
+#db_max_open_files = 400
 #fast-sync = 2048
 ```
 
@@ -367,7 +367,7 @@ Fulcrum will now index the whole Bitcoin blockchain so that it can provide all n
 
 DO NOT REBOOT OR STOP THE SERVICE DURING DB CREATION PROCESS. YOU MAY CORRUPT THE FILES - in case of that happening, start sync from scratch by deleting and recreating `fulcrum_db` folder.
 
-💡 Fulcrum must first fully index the blockchain and compact its database before you can connect to it with your wallets. This can take a few hours. Only proceed with the [Desktop Wallet Section](desktop-wallet.md) once Fulcrum is ready.
+💡 Fulcrum must first fully index the blockchain and compact its database before you can connect to it with your wallets. This can take a few hours. Only proceed with the [Desktop Wallet Section](../../bitcoin/desktop-wallet.md) once Fulcrum is ready.
 
 💡 After the initial sync of Fulcrum, if you want to still use zram, you can return to the default zram config.
 

--- a/guide/bonus/bitcoin/fulcrum.md
+++ b/guide/bonus/bitcoin/fulcrum.md
@@ -367,7 +367,7 @@ Fulcrum will now index the whole Bitcoin blockchain so that it can provide all n
 
 DO NOT REBOOT OR STOP THE SERVICE DURING DB CREATION PROCESS. YOU MAY CORRUPT THE FILES - in case of that happening, start sync from scratch by deleting and recreating `fulcrum_db` folder.
 
-💡 Fulcrum must first fully index the blockchain and compact its database before you can connect to it with your wallets. This can take up until ~3.5 - 4 days. Only proceed with the [Desktop Wallet Section](../../bitcoin/desktop-wallet.md) once Fulcrum is ready.
+💡 Fulcrum must first fully index the blockchain and compact its database before you can connect to it with your wallets. This can take up to ~3.5 - 4 days. Only proceed with the [Desktop Wallet Section](../../bitcoin/desktop-wallet.md) once Fulcrum is ready.
 
 💡 After the initial sync of Fulcrum, if you want to still use zram, you can return to the default zram config.
 
@@ -467,7 +467,7 @@ $ sudo systemctl restart btcrpcexplorer
 
 ### Backup the database
 
-Because the sync can take ~3.5 to 4 days, it is recommended to have at least any backup of the database. It doesn't need to be the latest one and you can backup only once. It is still better to sync for a few hours instead of a week (from scratch). Should be done on an external drive. Remember to stop Fulcrum before with `sudo systemctl stop fulcrum` command.
+If the database gets corrupted and you don't have a backup, you will have to resync it from scratch, which takes several days. This is why we recommend to make backups of the database once in a while, on an external drive. Like this, if something happens, you'll only have to resync since the date of your latest backup. Before doing the backup, remember to stop Fulcrum with `sudo systemctl stop fulcrum`
 
 ## For the future: Fulcrum upgrade
 

--- a/guide/bonus/bitcoin/fulcrum.md
+++ b/guide/bonus/bitcoin/fulcrum.md
@@ -467,7 +467,7 @@ $ sudo systemctl restart btcrpcexplorer
 
 ### Backup the database
 
-Because the sync can take up to 4 days and more, it is recommended to have at least any backup of the database. It doesn't need to be the latest one and you can backup only once, it is still better to sync for a few hours instead of week (from scratch). Should be done on external drive.
+Because the sync can take ~3.5 to 4 days, it is recommended to have at least any backup of the database. It doesn't need to be the latest one and you can backup only once. It is still better to sync for a few hours instead of a week (from scratch). Should be done on an external drive. Remember to stop Fulcrum before with `sudo systemctl stop fulcrum` command.
 
 ## For the future: Fulcrum upgrade
 


### PR DESCRIPTION
#### What

Improvement of `fulcrum.conf` configuration file and minor fix of redirect link wrong 

### Why

Why is this change important?

#### How

- Fixed wrong redirect link to Desktop Wallet core section
- Fixed `announce = false` parameter redundancy in `fulcrum.conf`
- Other minor redaction fixes

Following developer example-config:
https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf#L427-L435

#### Scope

- [ ] significant change to core configuration
- [X] independent bonus guide
- [ ] simple bug fix

#### Evidences

```sh
# Peering: announce self - 'announce' - DEFAULT: true if hostname and *peering
#                                                are set*, false otherwise
#
# You must enable `peering` above and also define a `hostname` for this to have
# an effect. If set to true and the above conditions are met, then your server
# will announce itself to peers and likely appear in their server lists. Setting
# this to true ensures you get more clients connecting to your server.
#
#announce = true
```
DEFAULT: true if hostname and *peering are set*, false otherwise

https://raspibolt.org/guide/bonus/bitcoin/fulcrum.html#configuration
```sh
peering = false
```