### PR TITLE
Adds UPS NUT bonus guide entry in index

### DIFF
--- a/guide/bonus/raspberry-pi/index.md
+++ b/guide/bonus/raspberry-pi/index.md
@@ -27,6 +27,11 @@ has_toc: false
 * **[Hardware-based (Trezor) SSH authentification](trezor-agent.md)** - a safer way to SSH to your device using your hardware wallet
 
 ---
+
+## Resilience
+* **[UPS NUT](ups-nut.md)** - have your RaspiBolt automatically and safely shutdown when a connected UPS reaches a critical power level
+
+---
 ## Hardware
 * **[Boot from microSD card](boot-from-microsd-card.md)** - if your Raspberry Pi is not able to boot directly from the external drive, these instructions explain how to boot from a microSD card and attach the external drive for data storage
 * **[Upgrade external drive](upgrade-external-drive.md)** - periodically, as the size of the blockchain grows, you will need to upgrade to a larger drive


### PR DESCRIPTION
#### What

The UPS NUT bonus guide did not have an entry in the Raspibolt bonus guides index. This PR adds such entry and link.

#### How

Added a new subsection "Resilience". 
But maybe could be placed under hardware? 

Note: It'd be useful to add a guide on how to choose and install a UPS.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Check the entry is there and the link is working
