### PR TITLE
Add missing separator + rewording of Safu Ninja blurb

### DIFF
--- a/guide/bonus/bitcoin/index.md
+++ b/guide/bonus/bitcoin/index.md
@@ -48,7 +48,9 @@ has_toc: false
 
 ## Resilience
 
-* **[Safu Ninja](safu-ninja.md)** - create DIY metal backups for your wallets' seed words
+* **[Safu Ninja](safu-ninja.md)** - create resilient DIY metal backups of your seed phrases
+
+---
 
 ## Fun
 


### PR DESCRIPTION
#### What

- Adds a missing separator in the bonus Bitcoin index page
- Rewording of the Safu Ninja blurb in the index to make it easier to read/understand

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix
