### PR TITLE
CLN: Remove reference to `poetry`

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -115,7 +115,7 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   $ git verify-tag v0.11.2
   ```
 
-* Download user specific python packages and set path for `poetry`.
+* Download user specific python packages.
 
   ```sh
   $ pip3 install --user mrkd==0.2.0


### PR DESCRIPTION
#### What / Why / How

Poetry was removed from CLN install guide in #1094, but there was still left reference to it in sentence describing commands. Remove that.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix