### PR TITLE
Add a "Secure your home network and devices" section to the "Preparations" chapter

### DIFF
--- a/guide/raspberry-pi/preparations.md
+++ b/guide/raspberry-pi/preparations.md
@@ -69,6 +69,14 @@ They should be unique and very secure, at least 12 characters in length. Do **no
 If you need inspiration for creating your passwords: the [xkcd: Password Strength](https://xkcd.com/936/){:target="_blank"} comic is funny and contains a lot of truth.
 Store a copy of your passwords somewhere safe (preferably in an open-source password manager like [KeePassXC](https://keepassxc.org/){:target="_blank"}), or whaterver password manager you're already using, and keep your original notes out of sight once your system is up and running.
 
+---
+
+## Secure your home network and devices
+
+While the guide will show you how to secure your node, you will interact with it from your computer and mobile phone and using your home internet network. Before building your RaspiBolt, it is recommended to secure your home network and devices.
+
+* Follow Part 1 and 2 of this ["How to Secure Your Home Network Against Threats"](https://restoreprivacy.com/secure-home-network/){:target="_blank"} tutorial by Heinrich Long, and try to implement as many points as possible (some might not apply to your router/device).
+
 <br /><br />
 
 ---


### PR DESCRIPTION
#### What

This PR is a proposal to add a recommendation to harden the security of the user home network and devices before starting building their node  (e.g. set WPA2, disable WPS, change admin password etc).

This is done through a new section at the end of the "Preparations" chapter; after creating all the passwords. The section introduces the rationales for securing the home networks and devices and points to a 3rd party tutorial (external URL).

While I prefer avoiding 3rd-party tutorials if possible, making an internal guide that goes through all the security tips might make that chapter a bit too long and be considered OOT.. (?)

I selected this guide: https://restoreprivacy.com/secure-home-network/ but if you know of a better/more reliable or trustworthy tutorial, please suggest an alternative URL.

### Why

Securing the home network and devices is a critical component of securing the use of a Bitcoin and Lightning node and new users would benefit from being guided on how to do it.

Wdyat?

#### Scope

- [ ] significant change to core configuration
- [x] minor change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Read the tutorial and check that its recommendations are valid and sufficient.
![security](https://media.giphy.com/media/RDZo7znAdn2u7sAcWH/giphy.gif)
