### PR TITLE
[UPDATE] Update privacy section to enable official Tor Package Repository

### DIFF
--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -47,9 +47,59 @@ Each node decrypts only the layer of information addressed to it, learning only 
 
 Log in to your RaspiBolt via SSH as user "admin" and install Tor.
 
+* Install apt-transport-https
+
   ```sh
-  $ sudo apt install tor
+  $ sudo apt install apt-transport-https
   ```
+
+* Create a new file called `tor.list`
+  
+  ```sh
+  $ sudo nano /etc/apt/sources.list.d/tor.list
+  ```
+
+* Add the following entries. Save and exit
+
+  ```sh
+  deb     [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bulleye main
+  deb-src [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bulleye main
+  ```
+
+* Then up to `"root"` user temporaly to add the gpg key used to sign the packages by running the following command at your command prompt. Return to `admin` using `exit` command
+
+  ```sh
+  $ sudo su
+  $ wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
+  $ exit
+  ```
+
+* Install tor and tor debian keyring
+
+   ```sh
+   $ sudo apt update
+   $ sudo apt install tor deb.torproject.org-keyring
+   ```
+
+* Check Tor has been correctly installed
+
+  ```sh
+  $ tor --version
+  > Tor version 0.4.7.10.
+  [...]
+  ```
+
+* Ensure that the Tor service is working and listening at the default ``9050` and `9051` ports
+
+```sh
+$ sudo lsof -i -P -n | grep tor | grep LISTEN
+```
+
+💡 If the prompt show you "sudo: lsof: command not found", it means that you don't have "lsof" installed yet, install it with next command and try again
+
+```sh
+$ sudo apt install lsof
+```
 
 ## Configuration
 
@@ -57,7 +107,7 @@ Bitcoin Core will communicate directly with the Tor daemon to route all traffic 
 We need to enable Tor to accept instructions through its control port, with the proper authentication.
 
 * Modify the Tor configuration by uncommenting (removing the `#`) or adding the following lines.
-  Save and exit
+Save and exit
 
   ```sh
   $ sudo nano /etc/tor/torrc
@@ -96,8 +146,8 @@ This makes "calling home" very easy, without the need to configure anything on y
 
 ### SSH server
 
-* Add the following three lines in the "location-hidden services" section of the `torrc` file.
-  Save and exit
+* Add the following three lines in the "location-hidden services" section of the `torrc` file. 
+Save and exit
 
   ```sh
   $ sudo nano /etc/tor/torrc

--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -62,11 +62,11 @@ Log in to your RaspiBolt via SSH as user "admin" and install Tor.
 * Add the following entries. Save and exit
 
   ```sh
-  deb     [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bulleye main
-  deb-src [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bulleye main
+  deb     [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main
+  deb-src [arch=arm64 signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main
   ```
 
-* Then up to `"root"` user temporaly to add the gpg key used to sign the packages by running the following command at your command prompt. Return to `admin` using `exit` command
+* Then up to `"root"` user temporarily to add the gpg key used to sign the packages by running the following command at your command prompt. Return to `admin` using `exit` command
 
   ```sh
   $ sudo su
@@ -89,7 +89,7 @@ Log in to your RaspiBolt via SSH as user "admin" and install Tor.
   [...]
   ```
 
-* Ensure that the Tor service is working and listening at the default ``9050` and `9051` ports
+* Ensure that the Tor service is working and listening at the default port `9050`.
 
 ```sh
 $ sudo lsof -i -P -n | grep tor | grep LISTEN
@@ -146,7 +146,7 @@ This makes "calling home" very easy, without the need to configure anything on y
 
 ### SSH server
 
-* Add the following three lines in the "location-hidden services" section of the `torrc` file. 
+* Add the following three lines in the "location-hidden services" section of the `torrc` file.
 Save and exit
 
   ```sh

--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -91,15 +91,15 @@ Log in to your RaspiBolt via SSH as user "admin" and install Tor.
 
 * Ensure that the Tor service is working and listening at the default port `9050`.
 
-```sh
-$ sudo lsof -i -P -n | grep tor | grep LISTEN
-```
+  ```sh
+  $ sudo lsof -i -P -n | grep tor | grep LISTEN
+  ```
 
 💡 If the prompt show you "sudo: lsof: command not found", it means that you don't have "lsof" installed yet, install it with next command and try again
 
-```sh
-$ sudo apt install lsof
-```
+  ```sh
+  $ sudo apt install lsof
+  ```
 
 ## Configuration
 

--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -92,13 +92,14 @@ Log in to your RaspiBolt via SSH as user "admin" and install Tor.
 * Ensure that the Tor service is working and listening at the default port `9050`.
 
   ```sh
-  $ sudo lsof -i -P -n | grep tor | grep LISTEN
+  $ sudo ss -tulpn | grep tor | grep LISTEN
   ```
 
-💡 If the prompt show you "sudo: lsof: command not found", it means that you don't have "lsof" installed yet, install it with next command and try again
+Expected output:
 
   ```sh
-  $ sudo apt install lsof
+  tcp   LISTEN 0      4096           127.0.0.1:9050       0.0.0.0:*    users:(("tor",pid=1847,fd=6))
+  tcp   LISTEN 0      4096           127.0.0.1:9051       0.0.0.0:*    users:(("tor",pid=1847,fd=7))
   ```
 
 ## Configuration

--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -89,7 +89,7 @@ Log in to your RaspiBolt via SSH as user "admin" and install Tor.
   [...]
   ```
 
-* Ensure that the Tor service is working and listening at the default port `9050`.
+* Ensure that the Tor service is working and listening at the default ports `9050` and `9150`
 
   ```sh
   $ sudo ss -tulpn | grep tor | grep LISTEN


### PR DESCRIPTION
#### What

This can lead to significant improvements in the correct running of the Raspibolt nodes.

#### Why

The Tor Project maintains its own Debian package repository. Since Debian provides the LTS version of Tor, this might not always give you the latest stable Tor version. Therefore, it's recommended to install tor from Tor official repository.
In addition, obtaining the latest release could help mitigate the current constant attack that the Tor network has been facing for months.

#### How

- Added the process to enable Tor Package Repository and install it from the official Tor repository
- Other improvements to Tor installation process

#### Scope

- [X] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

I tested all and is working fine for me:

```sh
$ tor --version
> Tor version 0.4.7.10.
[...]
```
```sh
tor          830      debian-tor    6u  IPv4  22995      0t0  TCP 127.0.0.1:9050 (LISTEN)
tor          830      debian-tor    7u  IPv4  22996      0t0  TCP 127.0.0.1:9051 (LISTEN)
```

#### References

https://support.torproject.org/apt/tor-deb-repo/
https://status.torproject.org/
https://www.torproject.org/download/tor/

#### Animated GIF

![giphy](https://user-images.githubusercontent.com/89636253/193410026-b0214152-c564-44e8-a32d-3d75508a5b66.gif)