### PR TITLE
Adds an Uninstall section to the LNBits bonus guide

### DIFF
--- a/guide/bonus/lightning/lnbits.md
+++ b/guide/bonus/lightning/lnbits.md
@@ -343,6 +343,64 @@ Updating to a [new release](https://github.com/lnbits/lnbits-legend/releases){:t
   $ sudo systemctl start lnbits
   ```
 
+---
+
+## Uninstall
+
+🚨 Warning: Before uninstalling LNBits, you might want to empty all your LNBits wallets.
+
+* Stop and disable the systemd service and then delete the service file
+ 
+  ```sh
+  $ sudo systemctl disable lnbits.service
+  $ sudo systemctl stop lnbits.service
+  $ sudo rm /etc/systemd/system/lnbits.service
+  ```
+
+* Display the UFW firewall rules and notes the numbers of the rules for Thunderhub (e.g., X and Y below)
+
+  ```sh  
+  $ sudo ufw status numbered
+  > [...]
+  > [X] 4003                   ALLOW IN    Anywhere                   # allow LNBits SSL
+  > [...]
+  > [Y] 4003 (v6)              ALLOW IN    Anywhere (v6)              # allow LNBits SSL
+  ```
+
+* Delete the two LNBits rules (check that the rule to be deleted is the correct one and type “y” and “Enter” when prompted)
+
+  ```sh 
+  $ sudo ufw delete Y
+  $ sudo ufw delete X
+  ```
+
+* Delete (or disable) the nginx reverse proxy configuration file
+
+  ```sh 
+  # to delete
+  $ sudo rm /etc/nginx/streams-enabled/lnbits-reverse-proxy.conf
+  
+  #to disable but preserve the configuration file
+  $ sudo mv /etc/nginx/streams-enabled/lnbits-reverse-proxy.conf /etc/nginx/streams-enabled/lnbits-reverse-proxy.conf.bak
+  ```
+
+* Test and reload nginx configuration
+
+  ```sh
+  $ sudo nginx -t
+  > nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
+  > nginx: configuration file /etc/nginx/nginx.conf test is successful
+  $ sudo systemctl reload nginx
+  ```
+
+* Delete the "lnbits" user. Do not worry about the `userdel: mempool mail spool (/var/mail/mempool) not found`.
+
+  ```sh
+  $ sudo su -
+  $ userdel -r lnbits
+  > userdel: lnbits mail spool (/var/mail/lnbits) not found
+  ```
+
 <br /><br />
 
 ---

--- a/guide/bonus/lightning/lnbits.md
+++ b/guide/bonus/lightning/lnbits.md
@@ -358,7 +358,7 @@ Updating to a [new release](https://github.com/lnbits/lnbits-legend/releases){:t
   $ sudo rm /etc/systemd/system/lnbits.service
   ```
 
-* Display the UFW firewall rules and notes the numbers of the rules for Thunderhub (e.g., X and Y below)
+* Display the UFW firewall rules and notes the numbers of the rules for LNBits (e.g., X and Y below)
 
   ```sh  
   $ sudo ufw status numbered

--- a/guide/bonus/lightning/lnbits.md
+++ b/guide/bonus/lightning/lnbits.md
@@ -42,6 +42,7 @@ Table of contents
 * Install necessary dependencies using the apt package manager.
 
   ```sh
+  $ sudo apt update
   $ sudo apt install libffi-dev libpq-dev python3-venv
   ```
 

--- a/guide/bonus/lightning/lnbits.md
+++ b/guide/bonus/lightning/lnbits.md
@@ -375,14 +375,10 @@ Updating to a [new release](https://github.com/lnbits/lnbits-legend/releases){:t
   $ sudo ufw delete X
   ```
 
-* Delete (or disable) the nginx reverse proxy configuration file
+* Delete the nginx reverse proxy configuration file
 
   ```sh 
-  # to delete
   $ sudo rm /etc/nginx/streams-enabled/lnbits-reverse-proxy.conf
-  
-  #to disable but preserve the configuration file
-  $ sudo mv /etc/nginx/streams-enabled/lnbits-reverse-proxy.conf /etc/nginx/streams-enabled/lnbits-reverse-proxy.conf.bak
   ```
 
 * Test and reload nginx configuration

--- a/guide/bonus/lightning/lnbits.md
+++ b/guide/bonus/lightning/lnbits.md
@@ -396,6 +396,7 @@ Updating to a [new release](https://github.com/lnbits/lnbits-legend/releases){:t
   $ sudo su -
   $ userdel -r lnbits
   > userdel: lnbits mail spool (/var/mail/lnbits) not found
+  $ exit
   ```
 
 <br /><br />


### PR DESCRIPTION
#### What

This PR adds an Uninstall section to the LNBits bonus guide.

### Why

To remove LNBits and keep the node tidy and without unused files.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] minor change to bonus guide
- [ ] simple bug fix

Fixes #1114 

#### Test & maintenance

Uninstall LNBits from the node.

![delete](https://media.giphy.com/media/de5bARu0SsXiU/giphy.gif)
