### PR TITLE
Update Lightning Terminal to v0.8.1 (contains the LND v0.15.2 hotfix)

### DIFF
--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -50,7 +50,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 
 We will configure Lightning Terminal to use our own LND node. However, when installing Lightning Terminal, it replaces the existing `lncli` binary (the CLI tool that allows us to interact with our LND daemon) with its own version of the `lncli` binary. The Lightining Terminal `lncli` binary is generally an older version and therefore might not have all the functionalities of the `lncli` associated with the version of LND that you're running. 
 
-Just don't be surpised if you want to use a brand new `lncli` command and it does not seem to be recognized! :)
+Just don't be surprised if you want to use a brand new `lncli` command and it does not seem to be recognized! :)
 
 ### Firewall
 

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -46,6 +46,12 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 
 ## Preparations
 
+### Warning
+
+We will configure Lightning Terminal to use our own LND node. However, when installing Lightning Terminal, it replaces the existing `lncli` binary (the CLI tool that allows us to interact with our LND daemon) with its own version of the `lncli` binary. The Lightining Terminal `lncli` binary is generally an older version and therefore might not have all the functionalities of the `lncli` associated with the version of LND that you're running. 
+
+Just don't be surpised if you want to use a brand new `lncli` command and it does not seem to be recognized! :)
+
 ### Firewall
 
 * Configure the UFW firewall to allow incoming HTTPS requests:

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -65,38 +65,44 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 
   ```sh
   $ cd /tmp
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.6.5-alpha/lightning-terminal-linux-arm64-v0.6.5-alpha.tar.gz
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.6.5-alpha/manifest-v0.6.5-alpha.txt
-  $ sha256sum --check manifest-v0.6.5-alpha.txt --ignore-missing
-  > lightning-terminal-linux-arm64-v0.6.5-alpha.tar.gz: OK
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.8.1-alpha/lightning-terminal-linux-arm64-v0.8.1-alpha.tar.gz
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.8.1-alpha/manifest-v0.8.1-alpha.txt
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.8.1-alpha/manifest-roasbeef-v0.8.1-alpha.sig
   ```
 
-* Import the project's lead maintainer (Oliver Gugger) PGP key from Keybase 
+* Verify the signed checksum against the actual checksum of your download
 
   ```sh
-  $ curl https://keybase.io/guggero/pgp_keys.asc | gpg --import
-  > [...]
-  > gpg: key 8E4256593F177720: "Oliver Gugger <gugger@gmail.com>" 1 new signature
-  > [...]
+  $ sha256sum --check manifest-v0.8.1-alpha.txt --ignore-missing
+  > lightning-terminal-linux-arm64-v0.8.1-alpha.tar.gz: OK
   ```
-  
-* Using the key, verify the authenticity of the checksums file
-  
+
+* You should already have Olaoluwa Osuntokun GPG public key from when you installed LND. If not, get the key to verify the manifest file; and add it to your GPG keyring.
+
   ```sh
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.6.5-alpha/manifest-v0.6.5-alpha.sig
-  $ gpg --verify manifest-v0.6.5-alpha.sig manifest-v0.6.5-alpha.txt
-  > [...]
-  > gpg: Good signature from "Oliver Gugger <gugger@gmail.com>" [unknown]
+  $ curl https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/roasbeef.asc | gpg --import
+  > ...
+  > gpg: key 372CBD7633C61696: public key "Olaoluwa Osuntokun <laolu32@gmail.com>" imported
+  > ...
+  ```
+
+* Verify the signature of the text file containing the checksums for the application
+
+  ```sh
+  $ gpg --verify manifest-roasbeef-v0.8.1-alpha.sig manifest-v0.8.1-alpha.txt
+  > gpg: Signature made Sun Oct  9 22:06:52 2022 PDT
+  > gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
+  > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [ultimate]
   > [...]
   ```
 
 * Now that the authenticity and integrity of the binary has been proven, unzip the binary and install Lightning Terminal
 
   ```sh
-  $ tar -xzf lightning-terminal-linux-arm64-v0.6.5-alpha.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lightning-terminal-linux-arm64-v0.6.5-alpha/*
+  $ tar -xzf lightning-terminal-linux-arm64-v0.8.1-alpha.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lightning-terminal-linux-arm64-v0.8.1-alpha/*
   $ litd --lnd.version
-  > litd version 0.14.2-beta commit=lightning-terminal-v0.6.5-alpha
+  > litd version 0.15.2-beta commit=lightning-terminal-v0.8.1-alpha
   ```
 
 ### User and data directories
@@ -468,7 +474,7 @@ If you have installed [Ride The Lightning](../../web-app.md), you can use the Lo
 
   ```sh
   $ litd --lnd.version
-  > litd version 0.14.1-beta commit=lightning-terminal-v0.6.1-alpha
+  > litd version 0.15.2-beta commit=lightning-terminal-v0.8.1-alpha
   ```
 
 * Read the [release notes](https://github.com/lightninglabs/lightning-terminal/releases){:target="_blank"} in case there is any breaking change to be aware of.

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -229,7 +229,7 @@ The settings for Pool, Faraday, Loop can all be put in the configuration file
   ###################
   
   # The Bitcoin node IP is the IP address of the Raspibolt, i.e. an address like 192.168.0.20
-  faraday.bitcoin.host=192.168.0.171
+  faraday.bitcoin.host=192.168.0.20
   # bitcoin.user provides to Faraday the bicoind RPC username, as specified in our bitcoin.conf
   faraday.bitcoin.user=raspibolt
   # bitcoin.password provides to Faraday the bitcoind RPC password, as specified in our bitcoin.conf


### PR DESCRIPTION
#### What

A PR to update Lighting Terminal to v0.8.1

### Why

- The guide is outdated (many versions behind)
- v0.8.1 contains the hot fix of LND v0.15.2. It does not really matter for this guide as the guidelines assume we are using an external LND node and NOT the one contained in Lightning Terminal... but just in case it's safer to have the guide with the version that contains the bug fix just in case a user would wnat to try out to use the LND as part of LiT..

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] update of bonus guide
- [ ] simple bug fix

#### Test & maintenance

- Verify syntax
- If possible, update on a node with LiT
