### PR TITLE
Update the guide for lnd v0.15.3-beta

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -32,9 +32,9 @@ We'll download, verify and install LND.
 
   ```sh
   $ cd /tmp
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.2-beta/lnd-linux-arm64-v0.15.2-beta.tar.gz
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.2-beta/manifest-v0.15.2-beta.txt
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.2-beta/manifest-roasbeef-v0.15.2-beta.sig
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.3-beta/lnd-linux-arm64-v0.15.3-beta.tar.gz
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.3-beta/manifest-v0.15.3-beta.txt
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.3-beta/manifest-roasbeef-v0.15.3-beta.sig
   ```
 
 * Get the public key from the LND developer, [Olaoluwa Osuntokun](https://keybase.io/roasbeef){:target="_blank"}, who signed the manifest file; and add it to your GPG keyring
@@ -49,7 +49,7 @@ We'll download, verify and install LND.
 * Verify the signature of the text file containing the checksums for the application
 
   ```sh
-  $ gpg --verify manifest-roasbeef-v0.15.2-beta.sig manifest-v0.15.2-beta.txt
+  $ gpg --verify manifest-roasbeef-v0.15.3-beta.sig manifest-v0.15.3-beta.txt
   > gpg: Signature made Sun Oct  9 20:36:23 2022 PDT
   > gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
   > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [ultimate]
@@ -59,17 +59,17 @@ We'll download, verify and install LND.
 * Verify the signed checksum against the actual checksum of your download
 
   ```sh
-  $ sha256sum --check manifest-v0.15.2-beta.txt --ignore-missing
-  > lnd-linux-arm64-v0.15.2-beta.tar.gz: OK
+  $ sha256sum --check manifest-v0.15.3-beta.txt --ignore-missing
+  > lnd-linux-arm64-v0.15.3-beta.tar.gz: OK
   ```
 
 * Install LND
 
   ```sh
-  $ tar -xzf lnd-linux-arm64-v0.15.2-beta.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.15.2-beta/*
+  $ tar -xzf lnd-linux-arm64-v0.15.3-beta.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.15.3-beta/*
   $ lnd --version
-  > lnd version 0.15.2-beta commit=v0.15.2-beta
+  > lnd version 0.15.3-beta commit=v0.15.3-beta
   ```
 
 ### Data directory


### PR DESCRIPTION
We wanted to wait for the update that includes the fix for the channel not announcing on opening bug and was initialy planned as 0.15.2-beta. Due to the critical out of sync bug, a hotfix was released under the tag 0.15.2-beta. Since we rushed to 0.15.2-beta to fix that bug, this PR is now requesting to update the main guide to 0.15.3-beta which now includes the channel not announcing on opening bug.

#### What

What is the reason of this change?

### Why

Why is this change important?

#### How

How was this change accomplished?

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?

#### Animated GIF (optional)

Add some snazz if you feel like it :)
