### PR TITLE
`ufw allow ssh` should be in lowercase

### DIFF
--- a/guide/raspberry-pi/security.md
+++ b/guide/raspberry-pi/security.md
@@ -127,7 +127,7 @@ We'll open the port for Electrs and web applications later if needed.
   $ sudo apt install ufw
   $ sudo ufw default deny incoming
   $ sudo ufw default allow outgoing
-  $ sudo ufw allow SSH
+  $ sudo ufw allow ssh
   $ sudo ufw logging off
   $ sudo ufw enable
   ```


### PR DESCRIPTION
Uppercase `SSH` gives me an error, lowercase works (Ubuntu Server).

```
admin ~ ₿ sudo ufw allow SSH 
ERROR: Could not find a profile matching 'SSH'
admin ~ ₿ sudo ufw allow ssh
Skipping adding existing rule
Skipping adding existing rule (v6)
```