### PR TITLE
Removed hold fee simulation section from Circuit Breaker guide (simulation does not exist anymore)

### DIFF
--- a/guide/bonus/lightning/circuit-breaker.md
+++ b/guide/bonus/lightning/circuit-breaker.md
@@ -161,26 +161,6 @@ By default, Circuit Breaker reads its configuration file located at `~/.circuitb
        #peers:
        #- 035cb74e3232e98ba6a866c485f1076dca5e42147dc1e3fbf9ea7241d359988e4d
    ```
-  
-* If you don't want to use the hold fees simulation, uncomment the entire section
-
-  ```ini
-  #holdFee:
-    # Set the base hold fee to 500 sat per hour to compensate for the usage of an
-    # htlc slot. If an imaginary channel of 1 BTC would have all of its 483 slots
-    # occupied for a full year, the total hold fee would be 24 * 365 * 483 =
-    # 4231080 sats. This translates to a yearly return on the staked bitcoin of
-    # ~4.2%.
-  #  baseSatPerHr: 1
-    # Set the hold fee rate to 5 parts per million. If an imaginary channel of 1
-    # BTC would have all of its funds time-locked for a full year, the total hold
-    # fee would be 24 * 365 * 100000000 * 5 / 1000000 = 4380000. This translates
-    # to a yearly return on the staked bitcoin of ~4.4%.
-  #  ratePpmPerHr: 5
-
-    # Report (virtually) collected hold fees once per hour.
-  #  reportingInterval: 1h*
-  ```
 
 * Once edited, save and exit.
 


### PR DESCRIPTION
#### What

Following [feedback from lead dev](https://github.com/lightningequipment/circuitbreaker/pull/6#discussion_r994573656), this PR removes an outdated section from the guide as the hold fee simulation has been [removed from Circuit Breaker](https://github.com/lightningequipment/circuitbreaker/commit/9a83573c046cab5962318d6d8fc34ca9f1d5ad10):

> Btw, I am removing hold fee simulation from circuitbreaker as it isn't core functionality. The guide is describing that part too.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix