### PR TITLE
Upgrade to lnd 0.15.4

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -34,25 +34,25 @@ We'll download, verify and install LND.
   $ cd /tmp
   $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.4-beta/lnd-linux-arm64-v0.15.4-beta.tar.gz
   $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.4-beta/manifest-v0.15.4-beta.txt
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.4-beta/manifest-roasbeef-v0.15.4-beta.sig
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.4-beta/manifest-guggero-v0.15.4-beta.sig
   ```
 
-* Get the public key from the LND developer, [Olaoluwa Osuntokun](https://keybase.io/roasbeef){:target="_blank"}, who signed the manifest file; and add it to your GPG keyring
+* Get the public key from the LND developer, [Oliver Gugger](https://keybase.io/guggero){:target="_blank"}, who signed the manifest file; and add it to your GPG keyring
 
   ```sh
-  $ curl https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/roasbeef.asc | gpg --import
+  $ curl https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/guggero.asc | gpg --import
   > ...
-  > gpg: key 372CBD7633C61696: public key "Olaoluwa Osuntokun <laolu32@gmail.com>" imported
+  > gpg: key 8E4256593F177720: "Oliver Gugger <gugger@gmail.com>" 1 new signature
   > ...
   ```
 
 * Verify the signature of the text file containing the checksums for the application
 
   ```sh
-  $ gpg --verify manifest-roasbeef-v0.15.4-beta.sig manifest-v0.15.4-beta.txt
-  > gpg: Signature made Mon Oct 17 23:18:02 2022 BST
-  > gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
-  > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [ultimate]
+  $ gpg --verify manifest-guggero-v0.15.4-beta.sig manifest-v0.15.4-beta.txt
+  > gpg: Signature made Tue Nov  1 13:00:20 2022 GMT
+  > gpg:                using RSA key F4FC70F07310028424EFC20A8E4256593F177720
+  > gpg: Good signature from "Oliver Gugger <gugger@gmail.com>" [unknown]
   > [...]
   ```
 
@@ -69,7 +69,7 @@ We'll download, verify and install LND.
   $ tar -xzf lnd-linux-arm64-v0.15.4-beta.tar.gz
   $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.15.4-beta/*
   $ lnd --version
-  > lnd version 0.15.3-beta commit=v0.15.4-beta
+  > lnd version 0.15.4-beta commit=v0.15.4-beta
   ```
 
 ### Data directory

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -32,9 +32,9 @@ We'll download, verify and install LND.
 
   ```sh
   $ cd /tmp
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.3-beta/lnd-linux-arm64-v0.15.3-beta.tar.gz
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.3-beta/manifest-v0.15.3-beta.txt
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.3-beta/manifest-roasbeef-v0.15.3-beta.sig
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.4-beta/lnd-linux-arm64-v0.15.4-beta.tar.gz
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.4-beta/manifest-v0.15.4-beta.txt
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.4-beta/manifest-roasbeef-v0.15.4-beta.sig
   ```
 
 * Get the public key from the LND developer, [Olaoluwa Osuntokun](https://keybase.io/roasbeef){:target="_blank"}, who signed the manifest file; and add it to your GPG keyring
@@ -49,7 +49,7 @@ We'll download, verify and install LND.
 * Verify the signature of the text file containing the checksums for the application
 
   ```sh
-  $ gpg --verify manifest-roasbeef-v0.15.3-beta.sig manifest-v0.15.3-beta.txt
+  $ gpg --verify manifest-roasbeef-v0.15.4-beta.sig manifest-v0.15.4-beta.txt
   > gpg: Signature made Mon Oct 17 23:18:02 2022 BST
   > gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
   > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [ultimate]
@@ -59,17 +59,17 @@ We'll download, verify and install LND.
 * Verify the signed checksum against the actual checksum of your download
 
   ```sh
-  $ sha256sum --check manifest-v0.15.3-beta.txt --ignore-missing
-  > lnd-linux-arm64-v0.15.3-beta.tar.gz: OK
+  $ sha256sum --check manifest-v0.15.4-beta.txt --ignore-missing
+  > lnd-linux-arm64-v0.15.4-beta.tar.gz: OK
   ```
 
 * Install LND
 
   ```sh
-  $ tar -xzf lnd-linux-arm64-v0.15.3-beta.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.15.3-beta/*
+  $ tar -xzf lnd-linux-arm64-v0.15.4-beta.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.15.4-beta/*
   $ lnd --version
-  > lnd version 0.15.3-beta commit=v0.15.3-beta
+  > lnd version 0.15.3-beta commit=v0.15.4-beta
   ```
 
 ### Data directory


### PR DESCRIPTION
Hotfix upgrade for chain sync.
gpg Signature timestamp needs to be adjusted once 0.15.4 is released