### PR TITLE
Fixes #848: Restarting Bitcoin Core without breaking BTC RPC Explorer

### DIFF
--- a/guide/bitcoin/blockchain-explorer.md
+++ b/guide/bitcoin/blockchain-explorer.md
@@ -275,6 +275,25 @@ In order to do that, we create a systemd unit that starts the service on boot di
   $ sudo journalctl -f -u btcrpcexplorer
   ```
 
+* Edit the Bitcoin Core service file to automatically starts the Explorer when Bitcoin Core starts
+
+  ```sh
+  $ sudo nano /etc/systemd/system/bitcoind.service
+  ```
+  
+  ```ini
+  [Unit]
+  Description=Bitcoin daemon
+  After=network.target
+  Wants=btcrpcexplorer.service
+  ```
+  
+* Reload the systemd manager configuration to recreate the entire dependency tree
+
+  ```sh
+  $ sudo systemctl daemon-reload
+  ```
+
 * You can now access your own BTC RPC Explorer from within your local network by browsing to <https://raspibolt.local:4000>{:target="_blank"} (or your equivalent IP address).
 
 ### Remote access over Tor (optional)

--- a/guide/bitcoin/blockchain-explorer.md
+++ b/guide/bitcoin/blockchain-explorer.md
@@ -252,7 +252,7 @@ In order to do that, we create a systemd unit that starts the service on boot di
 
   [Unit]
   Description=BTC RPC Explorer
-  After=network.target bitcoind.service electrs.service
+  After=bitcoind.service electrs.service
   PartOf=bitcoind.service
 
   [Service]

--- a/guide/bitcoin/blockchain-explorer.md
+++ b/guide/bitcoin/blockchain-explorer.md
@@ -252,8 +252,8 @@ In order to do that, we create a systemd unit that starts the service on boot di
 
   [Unit]
   Description=BTC RPC Explorer
-  After=network.target bitcoind.service
-  After=electrs.service
+  After=network.target bitcoind.service electrs.service
+  PartOf=bitcoind.service
 
   [Service]
   WorkingDirectory=/home/btcrpcexplorer/btc-rpc-explorer


### PR DESCRIPTION
#### What/WHy

_(following up the clossure of PR #1118 - this PR has a more focused scope)_

tl;dr: A PR to fix #848 : Restarting Bitcoin Core does not break BTC RPC Explorer

Bug: When Bitcoin Core is restarted, a new cookie file is generatd. But the Explorer does not notice and still use the older cookie file, which prevents the user to acces the Explorer (due to wrong Bitcoin Core RPC authentification). This is a mishandling of the cookie file by the Explorer and should be fixed in the Explorer codebase ittself. 

However, for the time being, we can use a work around.

This PR configures the systemd service files bitcoind.service and btcrcpexplorer.service in a way that when Bitcoin Core restarts (or stops and starts again), the BTC RPC also restarts (or stop and starts again). In this way, the Explorer is aware of the new cookie file generated by Bitcoin Core after the restart and so users can access the Explorer after a Bitcoin Core restart.

#### How

To do this, this PR makes the use of the following options:
- `PartOf` - manpage descrition below:
  > Configures dependencies similar to Requires=, but limited to stopping and restarting of units. 
  > When systemd stops or restarts the units listed here, the action is propagated to this unit. 
  > Note that this is a one-way dependency — changes to this unit do not affect the listed units

- `Wants` - manpage description below:
  > Configures (weak) requirement dependencies on other units. 
  > [...]
  > Units listed in this option will be started if the configuring unit is. 
  > However, if the listed units fail to start or cannot be added to the transaction, this has no impact on the validity of the transaction as a whole, and this unit will still be started. 
  > This is the recommended way to hook the start-up of one unit to the start-up of another unit.
  > Note that requirement dependencies do not influence the order in which services are started or stopped. This has to be configured independently with the After= or Before= options. [...]


We set the systemd service file this way:
- `bitcoind.service` -> we set a `Wants` requirement for `btcrpcexplorer.service`:
  ```
  [Unit] 
  Description=Bitcoin daemon
  After=network.target
  Wants=btcrpcexplorer.service
  ```
- In the `btcrpcexplorer.service` file, we set a` PartOf` requirement for `bitcoind.service`:
  ```
  [Unit]
  Description=BTC RPC Explorer daemon
  After=bitcoind.service electrs.service
  PartOf=bitcoind.service
  ```

The `PartOf` has the following goals:
  - When Bitcoin Core is stopped, the Explorer is stopped
  - When Bitcoin Core is restarted, the Explorer is restarted (only work for restarts, not start)

The `Wants` has the following goals:
  - When Bitcoin Core starts, it tries to start the Explorer
  - If it fails (e.g., the Explorer is not installed), then Bitcoin Core still starts nonetheless.

Both are needed, because, the bug can happen in the following two cases:
- Bitcoin Core is restarted -> the `PartOf` addition should be sufficient
- Bitcoin Core is stopped, and then started again -> in this case, both `PartOf` and `Wants` are needed. PartOf makes the Explorer stops when Core stops, while Wants make the Explorer starts again when Core is started again,

Note: could be applied to other apps as it allows for easy shutdown (e.g. just stop bitcoind and all the other services stop automatically)

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes #848 

#### Test & maintenance

Set the service files as above and try the following two tests:
- Test 1) Restart Bitcoin Core while BTC RPC Explorer is up (`sudo systemctl restart bitcoind.service`)
- Test 2) Stops Bitcoin Core, wait a bit, then starts it again (`sudo systemctl stop bitcoind.service` then `sudo systemctl start bitcoind.service`)

In both cases, once done, check if the Explorer is up again and can be properly accessed at https://rapsibolt.local:4000.

![plan](https://media.giphy.com/media/l0IylOPCNkiqOgMyA/giphy.gif)