### PR TITLE
Use "install" instead of "cp" when installing or updating Electrs

### DIFF
--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -342,7 +342,7 @@ Make sure to check the [release notes](https://github.com/romanz/electrs/blob/ma
 
   # Back up the old version and update
   $ sudo cp /usr/local/bin/electrs /usr/local/bin/electrs-old
-  $ sudo mv ./target/release/electrs /usr/local/bin/
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin ./target/release/electrs
 
   # Update the Electrs configuration if necessary (see release notes)
   $ nano /data/electrs/electrs.conf

--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -120,7 +120,7 @@ We get the latest release of the Electrs source code, verify it, compile it to a
 
   ```sh
   $ cargo build --locked --release
-  $ sudo cp ./target/release/electrs /usr/local/bin/
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin ./target/release/electrs
   ```
 
 ### Configuration


### PR DESCRIPTION
#### What

[Man page](https://linux.die.net/man/1/install) for `install`:

> This install program copies files (often just compiled) into destination locations you choose.

Some comparisons between cp and install are discussed [here](https://unix.stackexchange.com/questions/104982/why-use-install-rather-than-cp-and-mkdir). Notably:

> If copying over an existing file, cp overwrites the existing inode of the file, while install always creates a new inode for the same file name

Previous discussions on this change in closed PR #1102  [here](https://github.com/raspibolt/raspibolt/pull/1102#discussion_r981821131).

#### Why

More explicit and cleaner way to install & update Electrs

#### Scope

- [ ] significant change to core configuration
- [x] minor canage to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Update Electrs using new command