### PR TITLE
Update web-app.md

### DIFF
--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -164,7 +164,15 @@ Now we take the sample configuration file and add change it to our needs.
     "macaroonPath": "/home/rtl"
     "configPath": "/data/lnd/lnd.conf"
   ```
+  
+* Change `localhost` to `127.0.0.1` on the following lines to avoid errors
 
+  ```ini
+    "lnServerUrl": "https://127.0.0.1:8080"
+    "swapServerUrl": "https://127.0.0.1:8081"
+    "boltzServerUrl": "https://127.0.0.1:9003"
+  ```
+  
 * Save and exit
 
 


### PR DESCRIPTION
Change `localhost` to `127.0.0.1` in the RTL config file to avoid the following errors:
```
$ node rtl
[11/7/2022, 3:34:35 PM] INFO: RTL => Server is up and running, please open the UI at http://localhost:3000 or your proxy configured url.

[11/7/2022, 3:35:05 PM] ERROR: Common => Error in Channel Backup for xxxxx: connect ECONNREFUSED ::1:8080

[11/7/2022, 3:35:05 PM] ERROR: GetInfo => Get Info Error: {"name":"RequestError","message":"Error: connect ECONNREFUSED ::1:8080","cause":{"errno":-111,"code":"ECONNREFUSED","syscall":"connect","address":"::1","port":8080},"error":{"errno":-111,"code":"ECONNREFUSED","syscall":"connect","address":"::1","port":8080},"options":{"url":"https://localhost:8080/v1/getinfo","rejectUnauthorized":false,"json":true,"headers":{},"method":"GET","qs":{},"simple":true,"resolveWithFullResponse":false,"transform2xxOnly":false}}
```
Here is a link to an issue on the RTL GitHub describing the same problem with this change posted as the solution
https://github.com/Ride-The-Lightning/RTL/issues/1120

Here is a link to an issue I created in the LND GitHub trying to troubleshoot it before I figured it out. 
https://github.com/lightningnetwork/lnd/issues/7125
