### PR TITLE
Enhancements for the "Update" section of Electrs

### DIFF
--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -332,6 +332,11 @@ Make sure to check the [release notes](https://github.com/romanz/electrs/blob/ma
   $ git fetch
   $ git tag | sort --version-sort | tail -n 1
   > v0.9.10
+  
+  # Verify the release
+  $ git verify-tag v0.9.10
+  > gpg: Good signature from "Roman Zeyde <me@romanzey.de>" [unknown]
+  > [...]
 
   # Check out the most recent release (replace v0.9.10 with the actual version)
   # Should you encounter an error about files that would be overwritten use the -f argument to force the checkout

--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -353,7 +353,7 @@ Make sure to check the [release notes](https://github.com/romanz/electrs/blob/ma
   # Update the Electrs configuration if necessary (see release notes)
   $ nano /data/electrs/electrs.conf
 
-  # Start Electrs
+  # Restart Electrs
   $ sudo systemctl restart electrs
   ```
 

--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -327,7 +327,8 @@ Make sure to check the [release notes](https://github.com/romanz/electrs/blob/ma
   ```sh
   $ cd /home/admin/rust/electrs
 
-  # Update the local source code and show the latest release tag (example: v0.9.10)
+  # Clean and update the local source code and show the latest release tag (example: v0.9.10)
+  $ git clean -xfd
   $ git fetch
   $ git tag | sort --version-sort | tail -n 1
   > v0.9.10


### PR DESCRIPTION
#### What

A few improvements for the Update section of the Electrs guide as already discussed in closed PR #1102:

1. add `git clean -xfd` : suggested [here](https://github.com/raspibolt/raspibolt/issues/747#issue-956434374)
2. add `git verify-tag v0.9.10`: suggested [here](https://github.com/raspibolt/raspibolt/issues/747#issuecomment-1056786273)
3. fix typo in comment: "Restart" instead of "Start"

Addresses some suggestions from @Kixunil in #747 

### Why

More robust and safer update process

#### Scope

- [ ] significant change to core configuration
- [x] minor change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Update Electrs using the new commands.