### PR TITLE
Improve the Upgrade section of the regolancer bonus guide

### DIFF
--- a/guide/bonus/lightning/regolancer.md
+++ b/guide/bonus/lightning/regolancer.md
@@ -126,16 +126,14 @@ To run it continuously, you will need to run it in a loop or a cron.
 
   ```sh
   $ sudo su - regolancer
-  $ go install github.com/rkfg/regolancer@v1.6.x 
+  $ go install github.com/rkfg/regolancer@latest
   ```
-
-Please replace the v.1.6.x part with the version you would like to install.
 
 * Confirm if the upgrade was successfull
 
   ```sh
   $ go/bin/regolancer -v
-  Regolancer v1.6.3, built with go1.19.2
+  Regolancer v1.8.0, built with go1.19.2
   Source: https://github.com/rkfg/regolancer
   ```
 

--- a/guide/bonus/lightning/regolancer.md
+++ b/guide/bonus/lightning/regolancer.md
@@ -76,8 +76,9 @@ Table of contents
 * Create a working copy of the sample config file. You can use either .json or .toml configs, up to your preference.  
 
   ```sh
-  $ cp /home/regolancer/go/pkg/mod/github.com/rkfg/regolancer@v1.6.3/config.json.sample /home/regolancer/config.json
+  $ cp /home/regolancer/go/pkg/mod/github.com/rkfg/regolancer@v1.9.0/config.json.sample /home/regolancer/config.json
   ```
+Note: Adjust the "regolancer@v1.9.0" part from this commands to the actual version you have installed.
 
 * Make the newly created config.json file writable.
 

--- a/guide/bonus/lightning/regolancer.md
+++ b/guide/bonus/lightning/regolancer.md
@@ -62,7 +62,7 @@ Table of contents
 
   $ ln -s /data/lnd /home/regolancer/.lnd
 
-  $ go install github.com/rkfg/regolancer@v1.6.3
+  $ go install github.com/rkfg/regolancer@latest
   ```
 Note: Adjust the "regolancer@v1.6.3" part from the commands below to the actual version you have installed.
 
@@ -70,7 +70,7 @@ Note: Adjust the "regolancer@v1.6.3" part from the commands below to the actual 
 
   ```sh
   $ go/bin/regolancer -v
-  Regolancer v1.6.3, built with go1.19.2
+  Regolancer v1.9.0, built with go1.19.2
   Source: https://github.com/rkfg/regolancer
   ```
 
@@ -133,7 +133,7 @@ To run it continuously, you will need to run it in a loop or a cron.
 
   ```sh
   $ go/bin/regolancer -v
-  Regolancer v1.8.0, built with go1.19.2
+  Regolancer v1.9.0, built with go1.19.2
   Source: https://github.com/rkfg/regolancer
   ```
 

--- a/guide/bonus/lightning/regolancer.md
+++ b/guide/bonus/lightning/regolancer.md
@@ -64,7 +64,6 @@ Table of contents
 
   $ GOARCH=arm64 go install github.com/rkfg/regolancer@latest
   ```
-Note: Adjust the "regolancer@v1.6.3" part from the commands below to the actual version you have installed.
 
 * Confirm installed version
 

--- a/guide/bonus/lightning/regolancer.md
+++ b/guide/bonus/lightning/regolancer.md
@@ -62,7 +62,7 @@ Table of contents
 
   $ ln -s /data/lnd /home/regolancer/.lnd
 
-  $ go install github.com/rkfg/regolancer@latest
+  $ GOARCH=arm64 go install github.com/rkfg/regolancer@latest
   ```
 Note: Adjust the "regolancer@v1.6.3" part from the commands below to the actual version you have installed.
 


### PR DESCRIPTION
Changed the upgrade command from a specific version to the latest one. This makes it easier for users to upgrade, since they don't need to check the exact version number of the latest release.