### PR TITLE
[UPDATE SECURITY GUIDE] Minor fix of a SSH config deprecated parameter

### DIFF
--- a/guide/raspberry-pi/security.md
+++ b/guide/raspberry-pi/security.md
@@ -89,9 +89,10 @@ Follow this guide [Configure “No Password SSH Keys Authentication” with PuTT
   ```sh
   $ sudo nano /etc/ssh/sshd_config
   ```
+
   ```sh
   PasswordAuthentication no
-  ChallengeResponseAuthentication no
+  KbdInteractiveAuthentication no
   ```
 
 * Restart the SSH daemon, then exit your session
@@ -204,6 +205,7 @@ session required                        pam_limits.so
 $ sudo nano /etc/pam.d/common-session-noninteractive
 session required                        pam_limits.so
 ```
+
 ---
 
 ## Prepare NGINX reverse proxy


### PR DESCRIPTION
### What

I found `ChallengeResponseAuthentication` as a deprecated parameter in the docs

#### How

Changed deprecated parameter `ChallengeResponseAuthentication` to `KbdInteractiveAuthentication`

"ChallengeResponseAuthentication is a deprecated alias for this."
ref: https://man7.org/linux/man-pages/man5/sshd_config.5.html

#### Scope

- [X] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

I tested all and is working fine for me
