### PR TITLE
Fix formatting bugs in LNDg guide

### DIFF
--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -392,6 +392,7 @@ LNDg stores the LN node routing statistics and settings in a SQL database. We'll
           include /etc/nginx/conf.d/*.conf;
           include /etc/nginx/sites-enabled/*;
   }
+  ```
 
 * Create the log and sock files
 
@@ -406,6 +407,7 @@ LNDg stores the LN node routing statistics and settings in a SQL database. We'll
   $ sudo touch /home/lndg/lndg/lndg.sock
   $ sudo chown lndg:www-data /home/lndg/lndg/lndg.sock
   $ sudo chmod 660 /home/lndg/lndg/lndg.sock
+  ```
 
 * Test the nginx configuration
 


### PR DESCRIPTION
#### What

Missing closing backticks results in bad display in webpage.
Adds backticks to fix the issue.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Check that display is now OK