### PR TITLE
[UPDATE GUIDE] Tor: fix port and order

### DIFF
--- a/guide/raspberry-pi/privacy.md
+++ b/guide/raspberry-pi/privacy.md
@@ -89,19 +89,6 @@ Log in to your RaspiBolt via SSH as user "admin" and install Tor.
   [...]
   ```
 
-* Ensure that the Tor service is working and listening at the default ports `9050` and `9150`
-
-  ```sh
-  $ sudo ss -tulpn | grep tor | grep LISTEN
-  ```
-
-Expected output:
-
-  ```sh
-  tcp   LISTEN 0      4096           127.0.0.1:9050       0.0.0.0:*    users:(("tor",pid=1847,fd=6))
-  tcp   LISTEN 0      4096           127.0.0.1:9051       0.0.0.0:*    users:(("tor",pid=1847,fd=7))
-  ```
-
 ## Configuration
 
 Bitcoin Core will communicate directly with the Tor daemon to route all traffic through the Tor network.
@@ -127,6 +114,19 @@ Save and exit
 
   ```sh
   $ sudo systemctl reload tor
+  ```
+
+* Ensure that the Tor service is working and listening at the default ports `9050` and `9051`
+
+  ```sh
+  $ sudo ss -tulpn | grep tor | grep LISTEN
+  ```
+
+Expected output:
+
+  ```sh
+  tcp   LISTEN 0      4096           127.0.0.1:9050       0.0.0.0:*    users:(("tor",pid=1847,fd=6))
+  tcp   LISTEN 0      4096           127.0.0.1:9051       0.0.0.0:*    users:(("tor",pid=1847,fd=7))
   ```
 
 * Check the systemd journal to see Tor real time updates output logs.


### PR DESCRIPTION
### What

Two small fixes in Tor / Privacy guide: 
- wrong port: 9150 (Tor browser) -> 9051 (control port)
- 9051 only shows after activating controlport, so verifying open ports at a later point of time makes more sense to me.

### Why

You gotta do the right thing!

#### How

Replace and copy / pasta.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix