### PR TITLE
[UPDATE BONUS GUIDE] LNDg - htlc-stream-lndg - `Restart=always`

### DIFF
--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -616,7 +616,7 @@ LNDg uses a Python script (`~/lndg/htlc_stream.py`) to keep a log of failed HTLC
   User=lndg
   
   StandardError=append:/var/log/lnd_htlc_stream_error.log
-  Restart=on-failure
+  Restart=always
   RestartSec=60s
   
   [Install]


### PR DESCRIPTION
### What

Based on https://t.me/c/1442363505/33503 `htlc-stream-lndg.service` is set to `Restart=always` instead of `on-failure`.

### Why

Avoiding stuck service due to restarting method not activating.
Change is done in v1.4.0 branch of LNDg: https://github.com/cryptosharks131/lndg/blob/v1.4.0/systemd.md#htlc-failure-stream-data

#### How

Simple service file modification.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix