### PR TITLE
Fix problematic SSH config option instruction

### DIFF
--- a/guide/raspberry-pi/security.md
+++ b/guide/raspberry-pi/security.md
@@ -83,15 +83,22 @@ Follow this guide [Configure “No Password SSH Keys Authentication” with PuTT
 * Log in to the Raspberry Pi as "admin" using SSH with your SSH key.
   You shouldn't be prompted for the admin's password anymore.
 
-* Edit the ssh configuration file `/etc/ssh/sshd_config` by uncommenting the following two options and setting their value to `no`.
-  Save and exit.
-
+* Edit the ssh configuration file `/etc/ssh/sshd_config` to harden our security.
+  
   ```sh
   $ sudo nano /etc/ssh/sshd_config
   ```
 
+* Uncomment the following option to disable password authentification
+
   ```sh
   PasswordAuthentication no
+  ```
+
+* Below the the commented out `ChallengeResponseAuthentication` option, add the following line to disable s/key, a one-time password authentification
+
+  ```sh
+  #ChallengeResponseAuthentication no
   KbdInteractiveAuthentication no
   ```
 

--- a/guide/raspberry-pi/security.md
+++ b/guide/raspberry-pi/security.md
@@ -95,7 +95,7 @@ Follow this guide [Configure “No Password SSH Keys Authentication” with PuTT
   PasswordAuthentication no
   ```
 
-* Below the the commented out `ChallengeResponseAuthentication` option, add the following line to disable s/key, a one-time password authentification
+* Below the the commented out `ChallengeResponseAuthentication` option, add the following line to disable s/key, a one-time password authentification. Save and exit.
 
   ```sh
   #ChallengeResponseAuthentication no


### PR DESCRIPTION
#### What
PR to fix following issue: [https://github.com/raspibolt/raspibolt/pull/1164#issuecomment-1317018116](https://github.com/raspibolt/raspibolt/pull/1164#issuecomment-1317018116)

> Should the instructions for the changed lines be clarified since the default configuration file still includes the option's deprecated alias? Currently, the new KbdInteractiveAuthentication option must be manually added and the old option removed or commented out. The current instructional text only refers to "uncommenting the following two options" and the second option is currently not there to be uncommented.



#### How

Split the instruction in two parts. for the s/key option, ask to add a new line with the new superceding option (not present in the config file of the OS) below the commented out outdated option

> * Below the the commented out `ChallengeResponseAuthentication` option, add the following line to disable s/key, a one-time password authentification
> 
>   ```sh
>   #ChallengeResponseAuthentication no
>   KbdInteractiveAuthentication no
>   ```

Rephrased entire paragraph t make it clearer and add some explanations about the 2 options

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Check new instruction is ok for new users starting with fresh OS.