### PR TITLE
Fix small typoin SSH guide

### DIFF
--- a/guide/raspberry-pi/security.md
+++ b/guide/raspberry-pi/security.md
@@ -95,7 +95,7 @@ Follow this guide [Configure “No Password SSH Keys Authentication” with PuTT
   PasswordAuthentication no
   ```
 
-* Below the the commented out `ChallengeResponseAuthentication` option, add the following line to disable s/key, a one-time password authentification. Save and exit.
+* Below the commented out `ChallengeResponseAuthentication` option, add the following line to disable s/key, a one-time password authentification. Save and exit.
 
   ```sh
   #ChallengeResponseAuthentication no


### PR DESCRIPTION
Fix small typo in SSH guide: duplicated "the"

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix