### PR TITLE
Instructions to add CLN REST over Tor and CLN QR code generation for Zeus

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -591,7 +591,7 @@ The Zeus mobile app will access the node via Tor.
   ```
 
   ```
-  c-lightning-rest://<tor-address>:8080?&macaroon=<macaroon-in-hexadecimal>&protocol=http
+  c-lightning-rest://http://<tor-address>:8080?&macaroon=<macaroon-in-hexadecimal>&protocol=http
   ```
 
 * Generate a QR code:

--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -577,7 +577,7 @@ The Zeus mobile app will access the node via Tor.
   $ sudo apt install qrencode
   ```
 
-* Prepare QR data by finding the:
+* Prepare QR data:
 
   ```sh
   $ cd /data/lightningd-plugins-available/c-lightning-REST-0.9.0/certs


### PR DESCRIPTION
#### What

Adding additional information on how to expose CLN REST over Tor and generate a QR code for Zeus node configuration.

### Why

These change exist in the documentation for LND, but it is left largely to the user to figure out how to fill the gaps if they choose to run a CLN node.

#### How

Copied proces from LND documentation and help on QR code generation here:

https://github.com/ZeusLN/zeus/issues/515

along with linked Twitter post and some help from `elkaladiente` in Rapibolt Telegram channel.

#### Scope

- [ ] significant change to core configuration
- [x ] independent bonus guide
- [ ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?

Test by trying to connect Zeus application to CLN with QR code over Tor.

#### Animated GIF (optional)

Add some snazz if you feel like it :)
