### PR TITLE
Bitcoin guide update ots verification: Pip3 installation step 

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -52,6 +52,9 @@ This is a precaution to make sure that this is an official release and not a mal
 
   # download the signatures attesting to validity of the checksums
   $ wget https://bitcoincore.org/bin/bitcoin-core-23.0/SHA256SUMS.asc
+
+  # download the OpenTimestamp proof
+  $ wget https://bitcoincore.org/bin/bitcoin-core-24.0/SHA256SUMS.ots
   ```
 
 ### Checksum check
@@ -90,7 +93,11 @@ This is a precaution to make sure that this is an official release and not a mal
 
 ### Timestamp check
 
-* The binary checksum file is timestamped on the Bitcoin blockchain via the [OpenTimestamps protocol](https://opentimestamps.org/){:target="_blank"}, proving that the file existed prior to some point in time. Let's verify this timestamp. On your local computer, download the checksums file and its timestamp proof:
+* The binary checksum file is timestamped on the Bitcoin blockchain via the [OpenTimestamps protocol](https://opentimestamps.org/){:target="_blank"} (OTS from now on), proving that the file existed prior to some point in time.
+
+#### First installation check
+* Since the OTS protocol needs a running Bitcoin node to independently perform the timestamp verification, for this time only, we are going to verify it through the OTS website.
+On your local computer, download the checksums file and its timestamp proof:
   *  https://bitcoincore.org/bin/bitcoin-core-23.0/SHA256SUMS.ots
   *  https://bitcoincore.org/bin/bitcoin-core-23.0/SHA256SUMS
 * In your browser, open the [OpenTimestamps website](https://opentimestamps.org/){:target="_blank"}
@@ -99,6 +106,16 @@ This is a precaution to make sure that this is an official release and not a mal
 * If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v23.0){:target="_blank"} of Bitcoin Core v23.0.
 
 ![Bitcoin timestamp check](../../images/bitcoin-ots-check.PNG)
+
+#### Future upgrades
+* For future upgrades performed after the OTS installation you can independently verify the OpenTimestamp proof.
+
+```sh
+$ ots verify SHA256SUMS.ots
+> Assuming target filename is 'SHA256SUMS'
+> Got 3 attestation(s) from cache
+> Success! Bitcoin block 764525 attests existence as of 2022-11-24 GMT
+```
 
 ### Installation
 

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -480,7 +480,7 @@ Now that Bitcoin Core is running and synced, we can install the [OpenTimestamp c
 
 * With user "admin", globally install the Python package manager Pip3
 
-```sh
+  ```sh
   $ sudo apt install python3-pip
   ```
 

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -76,7 +76,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
 * Verify that the checksums file is cryptographically signed by the release signing keys.
   The following command prints signature checks for each of the public keys that signed the checksums.
-  
+
   ```sh
   $ gpg --verify SHA256SUMS.asc
   ```
@@ -472,19 +472,25 @@ We also now want to enable the node to listen to and relay transactions.
 
 ## OpenTimestamps client
 
-When we installed Bitcoin Core, we verified the timestamp of the checksum file using the OpenTimestamp website. 
+When we installed Bitcoin Core, we verified the timestamp of the checksum file using the OpenTimestamp website.
 
 In the future, you will likely need to verify more timestamps, when installing additional programs (_e.g._ LND) and when updating existing programs to a newer version. Rather than relying on a third-party, it would be preferable (and more fun!) to verify the timestamps using your own blockchain data.
 
 Now that Bitcoin Core is running and synced, we can install the [OpenTimestamp client](https://github.com/opentimestamps/opentimestamps-client){:target="_blank"} to locally verify the timestamp of the checksums file.
 
-* With user "admin", globally install the OpenTimestamp client
+* With user "admin", globally install the Python package manager Pip3
+
+```sh
+  $ sudo apt install python3-pip
+  ```
+
+* Install OpenTimestamp client
 
   ```sh
   $ sudo pip3 install opentimestamps-client
   ```
 
-* Display the OpenTimestamps client version to check that it is properly installed 
+* Display the OpenTimestamps client version to check that it is properly installed
 
   ```sh
   $ ots --version

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -45,13 +45,13 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   # download Bitcoin Core binary
-  $ wget https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-aarch64-linux-gnu.tar.gz
+  $ wget https://bitcoincore.org/bin/bitcoin-core-24.0/bitcoin-24.0-aarch64-linux-gnu.tar.gz
 
   # download the list of cryptographic checksum
-  $ wget https://bitcoincore.org/bin/bitcoin-core-23.0/SHA256SUMS
+  $ wget https://bitcoincore.org/bin/bitcoin-core-24.0/SHA256SUMS
 
   # download the signatures attesting to validity of the checksums
-  $ wget https://bitcoincore.org/bin/bitcoin-core-23.0/SHA256SUMS.asc
+  $ wget https://bitcoincore.org/bin/bitcoin-core-24.0/SHA256SUMS.asc
 
   # download the OpenTimestamp proof
   $ wget https://bitcoincore.org/bin/bitcoin-core-24.0/SHA256SUMS.ots
@@ -63,7 +63,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   $ sha256sum --ignore-missing --check SHA256SUMS
-  > bitcoin-23.0-aarch64-linux-gnu.tar.gz: OK
+  > bitcoin-24.0-aarch64-linux-gnu.tar.gz: OK
   ```
 
 ### Signature check
@@ -98,12 +98,12 @@ This is a precaution to make sure that this is an official release and not a mal
 #### First installation check
 * Since the OTS protocol needs a running Bitcoin node to independently perform the timestamp verification, for this time only, we are going to verify it through the OTS website.
 On your local computer, download the checksums file and its timestamp proof:
-  *  https://bitcoincore.org/bin/bitcoin-core-23.0/SHA256SUMS.ots
-  *  https://bitcoincore.org/bin/bitcoin-core-23.0/SHA256SUMS
+  *  https://bitcoincore.org/bin/bitcoin-core-24.0/SHA256SUMS.ots
+  *  https://bitcoincore.org/bin/bitcoin-core-24.0/SHA256SUMS
 * In your browser, open the [OpenTimestamps website](https://opentimestamps.org/){:target="_blank"}
 * In the "Stamp and verify" section, drop or upload the downloaded SHA256SUMS.ots proof file in the dotted box
 * In the next box, drop or upload the SHA256SUMS file
-* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v23.0){:target="_blank"} of Bitcoin Core v23.0.
+* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v24.0){:target="_blank"} of Bitcoin Core v24.0.
 
 ![Bitcoin timestamp check](../../images/bitcoin-ots-check.PNG)
 
@@ -125,10 +125,10 @@ $ ots verify SHA256SUMS.ots
 * If you're satisfied with the checkum, signature and timestamp checks, extract the Bitcoin Core binaries, install them and check the version.
 
   ```sh
-  $ tar -xvf bitcoin-23.0-aarch64-linux-gnu.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-23.0/bin/*
+  $ tar -xvf bitcoin-24.0-aarch64-linux-gnu.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-24.0/bin/*
   $ bitcoind --version
-  > Bitcoin Core version v23.0.0
+  > Bitcoin Core version v24.0.0
   > [...]
   ```
 

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -108,7 +108,7 @@ On your local computer, download the checksums file and its timestamp proof:
 ![Bitcoin timestamp check](../../images/bitcoin-ots-check.PNG)
 
 #### Future upgrades
-* For future upgrades performed after the OTS installation you can independently verify the OpenTimestamp proof.
+* For future upgrades, performed after the OTS installation, you can independently verify the OpenTimestamp proof from your RaspiBolt.
 
 ```sh
 $ ots verify SHA256SUMS.ots

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -113,7 +113,10 @@ On your local computer, download the checksums file and its timestamp proof:
 ```sh
 $ ots verify SHA256SUMS.ots
 > Assuming target filename is 'SHA256SUMS'
-> Got 3 attestation(s) from cache
+> Got 1 attestation(s) from https://btc.calendar.catallaxy.com
+> Got 1 attestation(s) from https://finney.calendar.eternitywall.com
+> Got 1 attestation(s) from https://bob.btc.calendar.opentimestamps.org
+> Got 1 attestation(s) from https://alice.btc.calendar.opentimestamps.org
 > Success! Bitcoin block 764525 attests existence as of 2022-11-24 GMT
 ```
 

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -494,8 +494,6 @@ We also now want to enable the node to listen to and relay transactions.
 
 When we installed Bitcoin Core, we verified the timestamp of the checksum file using the OpenTimestamp website.
 
-In the future, you will likely need to verify more timestamps, when installing additional programs (_e.g._ LND) and when updating existing programs to a newer version. Rather than relying on a third-party, it would be preferable (and more fun!) to verify the timestamps using your own blockchain data.
-
 Now that Bitcoin Core is running and synced, we can install the [OpenTimestamp client](https://github.com/opentimestamps/opentimestamps-client){:target="_blank"} to locally verify the timestamp of the checksums file.
 
 * With user "admin", globally install the Python package manager Pip3


### PR DESCRIPTION
#### What

Even though Python 3 is included in Raspberry Pi OS Lite 64-bit, the Python-Pip3 package is reported as missing when you try to install opentimestamps-client. This PR add the one line needed to install Python-Pip3 package prior to opentimestamps client installation on top of the v23 -> v24 updated procedure.
It also explains how to verify the OTS proof during the future upgrades.

### Why

The change is relevant to help users with low or no confidence with packages installation to get to the expected result which is get OTS installed on their raspibolt.

#### How

The change is just one line of code self-tested.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix

Fixes #1190 