### PR TITLE
[UPDATE BONUS GUIDE] bump version to v22.11

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -110,8 +110,7 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
 * Don't trust, verify! Check who released the current version and get their signing keys and verify checksums. Verification step should output `Good Signature`.
 
   ```sh
-  $ wget -O "pgp_keys.asc" https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/cdecker.txt
-  $ gpg --import ./pgp_keys.asc
+  $ curl https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/cdecker.txt | gpg --import
   $ git verify-tag v22.11
   ```
 
@@ -303,6 +302,13 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   ```sh
   $ sudo systemctl restart lightningd.service
   ```
+  
+* ⚠️ Regarding upgrading to v22.11: If you encounter an error upgrading to v22.11 saying "upgrading to a non-final version v22.11", edit `config` and temporarily add the following parameter: 
+
+  ```ini
+  database-upgrade=true
+  ```
+  Background: This parameter was introduced to make clear that the user upgrades the database to a non-final version. The database migration cannot be undone. The recommendation therefore is to set this only once if you experience this issue and delete the parameter when the migration was successfull. Note: There's no migration happening to v22.11, so in case of failures, you still can go back to v0.12.1 or earlier versions.
 
 ## Optional Steps
 

--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -118,8 +118,6 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
 * Download user specific python packages.
 
   ```sh
-  $ pip3 install --user mrkd==0.2.0
-  $ pip3 install --user mistune==0.8.4
   $ pip3 install --user mako
   ```
 

--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -104,15 +104,15 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   $ git clone https://github.com/ElementsProject/lightning.git
   $ cd lightning
   $ git fetch --all --tags
-  $ git reset --hard v0.11.2
+  $ git reset --hard v22.11
   ``` 
 
 * Don't trust, verify! Check who released the current version and get their signing keys and verify checksums. Verification step should output `Good Signature`.
 
   ```sh
-  $ wget -O "pgp_keys.asc" https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/rustyrussell.txt
+  $ wget -O "pgp_keys.asc" https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/cdecker.txt
   $ gpg --import ./pgp_keys.asc
-  $ git verify-tag v0.11.2
+  $ git verify-tag v22.11
   ```
 
 * Download user specific python packages.


### PR DESCRIPTION
### What

What is the reason of this change?

- signing key change (cdecker)
- version bump with `git reset --hard`

### Why

keeping updated to latest release versions

### How

How was this change accomplished?

### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple update

### Draft

Draft until problematic issue regarding database upgrade warning. Requires setting flag `database-upgrade` for non-final versions although v22.11 should be identified as final.