### PR TITLE
Change the default base fee and fee rate for lnd

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -193,8 +193,8 @@ To improve the security of your wallet, check out these more advanced methods:
   wallet-unlock-allow-create=true
 
   # Channel settings
-  bitcoin.basefee=1000
-  bitcoin.feerate=1
+  bitcoin.basefee=0
+  bitcoin.feerate=2500
   minchansize=100000
   accept-keysend=true
   accept-amp=true


### PR DESCRIPTION
This PR changes the default base fee to 0 to support the #zerobasefee initiative. This will make pathfinding a linear mathematical problem that is much easier to solve. For further information see here:
https://arxiv.org/pdf/2107.05322.pdf
http://www.rene-pickhardt.de

Additionally, this PR sets the default fee rate for newly opened channels to 2500 ppm. This will prohibit channels opened to sink nodes from draining instantly after opening.