### PR TITLE
Update lightning-client.md

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -193,7 +193,13 @@ To improve the security of your wallet, check out these more advanced methods:
   wallet-unlock-allow-create=true
 
   # Automatically regenerate certificate when near expiration
-  tlsautorefresh=1
+  tlsautorefresh=true
+  # Do not include the interface IPs or the system hostname in TLS certificate.
+  tlsdisableautofill=true
+  # Explicitly define any additional domain names for the certificate that will be created.
+  # tlsextradomain=raspibolt.local
+  # tlsextradomain=raspibolt.public.domainname.com
+  
 
   # Channel settings
   bitcoin.basefee=1000

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -192,6 +192,9 @@ To improve the security of your wallet, check out these more advanced methods:
   wallet-unlock-password-file=/data/lnd/password.txt
   wallet-unlock-allow-create=true
 
+  # Automatically regenerate certificate when near expiration
+  tlsautorefresh=1
+
   # Channel settings
   bitcoin.basefee=1000
   bitcoin.feerate=1


### PR DESCRIPTION
Set tlsautorefresh=true.
Fixes #1115

#### What

Add setting to auto refresh TLS cert

### Why

Certs expire (I think setting is 1 year after creation).  And when they do remote queries and RPC calls like unlock wallet can fail.

#### How

Configuration change added to lnd.conf

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

Fixes #1115

#### Test & maintenance

To test this issue requires running LND for some time and waiting for cert expiration and then check if recreated.

