### PR TITLE
docs: add note about ufw cannot determine iptables version issue

### DIFF
--- a/guide/raspberry-pi/security.md
+++ b/guide/raspberry-pi/security.md
@@ -131,6 +131,8 @@ We'll open the port for Electrs and web applications later if needed.
 
 * With user "admin", configure and enable the firewall rules
 
+  ℹ️ *Note:* if you are seeing: `ERROR: Couldn't determine iptables version` you may need to reboot after installing `ufw` 
+
   ```sh
   $ sudo apt install ufw
   $ sudo ufw default deny incoming


### PR DESCRIPTION
#### What

After installing ufw I recieved the following error:

```
ERROR: Couldn't determine iptables version
```

### Why

new users may be confused

#### How

I added a note

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [ x] simple bug fix

