### PR TITLE
[UPDATE WEB APP GUIDE] Push RTL to v0.13.3

### DIFF
--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -27,7 +27,6 @@ We install [Ride The Lightning](https://github.com/Ride-The-Lightning/RTL#readme
 ### Install Node.js
 
 Starting with user “admin”, we add the Node.js package repository.
-We’ll use version 16 which is the latest stable version.
 If you installed BTC RPC Explorer, then you've already accomplished this step.
 
 * Add the Node.js (LTS version) software repository

--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -30,10 +30,10 @@ Starting with user “admin”, we add the Node.js package repository.
 We’ll use version 16 which is the latest stable version.
 If you installed BTC RPC Explorer, then you've already accomplished this step.
 
-* Add the Node.js software repository
+* Add the Node.js (LTS version) software repository
 
   ```sh
-  $ curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+  $ curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
   ```
 
 * Install Node.js using the apt package manager
@@ -103,11 +103,11 @@ We do not want to run Ride the Lightning alongside bitcoind and lnd because of s
   $ cd RTL
 
   $ git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1
-  > v0.13.2
+  > v0.13.3
 
-  $ git checkout v0.13.2
+  $ git checkout v0.13.3
 
-  $ git verify-tag v0.13.2
+  $ git verify-tag v0.13.3
   > gpg: Signature made Tue 22 Nov 2022 03:04:55 CET
   > gpg:                using RSA key 3E9BD4436C288039CA827A9200C9E2BC2E45666F
   > gpg: Good signature from "saubyk (added uid) <39208279+saubyk@users.noreply.github.com>" [unknown]
@@ -121,7 +121,7 @@ We do not want to run Ride the Lightning alongside bitcoind and lnd because of s
   Downloading all dependencies can sometimes be very slow, so be patient and let the process run its course.
 
   ```sh
-  $ npm install --omit=dev
+  $ npm install --omit=dev --legacy-peer-deps
   ```
 
 The installation can take some time, and can hang on a single package for a long time.


### PR DESCRIPTION
### What

Push RTL to version 0.13.3.

### Why

- Keep up to latest version. Different installation commands used.
- Use LTS version (currently v18) of Node.js

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple guide update
