### PR TITLE
Fix broken image link in updated BitBox guide

### DIFF
--- a/guide/bonus/bitcoin/bitboxapp.md
+++ b/guide/bonus/bitcoin/bitboxapp.md
@@ -43,7 +43,7 @@ Table of contents
 
 Restart the BitBoxApp to make sure all changes take effect and you're all set!
 
-![Successfully established connection](../../images/bitboxapp_success.png)
+![Successfully established connection](../../../images/bitboxapp_success.png)
 
 ## Connecting to your RaspiBolt with Tor
 
@@ -73,8 +73,7 @@ $ sudo cat /var/lib/tor/hidden_service_electrs/hostname
 
 Restart the BitBoxApp to make sure all changes take effect and you're all set!
 
-![Successfully established connection with Tor](../../images/bitboxapp_tor_success.png)
-
+![Successfully established connection with Tor](../../../images/bitboxapp_tor_success.png)
 
 <br /><br />
 


### PR DESCRIPTION
#### What

Image link in updated BitBox guide is broken

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix


#### Test & maintenance

Tested it offline now and it should work... 

#### Animated GIF (optional)

![giphy](https://user-images.githubusercontent.com/79049748/210963083-a19def0c-ebc9-4bf4-aa9c-07f9a1070c07.gif)
