### PR TITLE
Change bitcoind systemd service to use exec process type

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -268,12 +268,6 @@ Still logged in as user "bitcoin", let's start "bitcoind" manually.
 
 * Once everything looks ok, stop "bitcoind" with `Ctrl-C`
 
-* Grant the "bitcoin" group read-permission for the debug log file:
-
-  ```sh
-  $ chmod g+r /data/bitcoin/debug.log
-  ```
-
 * Exit the “bitcoin” user session back to user “admin”
 
   ```sh
@@ -312,7 +306,7 @@ We use “systemd“, a daemon that controls the startup process using configura
   # Service execution
   ###################
 
-  ExecStart=/usr/local/bin/bitcoind -daemon \
+  ExecStart=/usr/local/bin/bitcoind -nodebuglogfile \
                                     -pid=/run/bitcoind/bitcoind.pid \
                                     -conf=/home/bitcoin/.bitcoin/bitcoin.conf \
                                     -datadir=/home/bitcoin/.bitcoin \
@@ -320,7 +314,7 @@ We use “systemd“, a daemon that controls the startup process using configura
 
   # Process management
   ####################
-  Type=forking
+  Type=exec
   PIDFile=/run/bitcoind/bitcoind.pid
   Restart=on-failure
   TimeoutSec=300
@@ -401,11 +395,11 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   > -rw-r----- 1 bitcoin bitcoin 75 Dec 17 13:48 /home/bitcoin/.bitcoin/.cookie
   ```
 
-* See "bitcoind" in action by monitoring its log file.
+* See "bitcoind" in action by viewing its logged output.
   Exit with `Ctrl-C`
 
   ```sh
-  $ tail -f /home/bitcoin/.bitcoin/debug.log
+  $ journalctl -f -u bitcoind
   ```
 
 * Use the Bitcoin Core client `bitcoin-cli` to get information about the current blockchain

--- a/guide/bitcoin/blockchain-explorer.md
+++ b/guide/bitcoin/blockchain-explorer.md
@@ -51,7 +51,7 @@ For the BTC RPC Explorer to work, you need your full node to index all transacti
   ```
 
 Please note that reindexing can take more than a day.
-You can follow the progress using `tail -f ~/.bitcoin/debug.log`.
+You can follow the progress using `journalctl -f -u bitcoind`.
 
 ### Install Node.js
 

--- a/guide/bonus/bitcoin/electrum-personal-server.md
+++ b/guide/bonus/bitcoin/electrum-personal-server.md
@@ -150,9 +150,9 @@ The Electrum Personal Server scripts are installed in the directory `/home/bitco
     $ /home/bitcoin/.local/bin/electrum-personal-server --rescan /home/bitcoin/electrum-personal-server/config.cfg
     ```
 
-  * You can monitor the rescan progress in the Bitcoin Core logfile from a second SSH session:
+  * You can monitor the rescan progress in the Bitcoin Core log output from a second SSH session:
     ```sh
-    $ sudo tail -f /home/bitcoin/.bitcoin/debug.log
+    $ journalctl -f -u bitcoind
     ```
 
   * Run Electrum Personal Server again and connect your Electrum wallet from your regular computer.

--- a/guide/bonus/raspberry-pi/odroid-setup.md
+++ b/guide/bonus/raspberry-pi/odroid-setup.md
@@ -232,7 +232,7 @@ After=network.target
 # Service execution
 ###################
 
-ExecStart=/usr/local/bin/bitcoind -daemon \
+ExecStart=/usr/local/bin/bitcoind -nodebuglogfile \
                                   -pid=/run/bitcoind/bitcoind.pid \
                                   -conf=/mnt/ext/bitcoin/bitcoin.conf \
                                   -datadir=/mnt/ext/bitcoin
@@ -241,7 +241,7 @@ ExecStart=/usr/local/bin/bitcoind -daemon \
 # Process management
 ####################
 
-Type=forking
+Type=exec
 PIDFile=/run/bitcoind/bitcoind.pid
 Restart=on-failure
 TimeoutSec=300
@@ -300,7 +300,7 @@ Give it a few minutes to reboot, log in again via SSH with user root.
 #### Explore bitcoind and bitcoind-cli
 
 Now that bitcoind is running, you have various ways to check download progress and look into the blockchain data.
-* Look at the tail end of the log file: `tail -f /mnt/ext/bitcoin/debug.log `. Ctrl-C to get out of this logging view. This will tell you also the progress of the blockchain download. When you reach near 0.99 or 1.0 you have downloaded 100% of the blockchain and are 'caught up'
+* Look at the latest log output: `journalctl -f -u bitcoind`. Ctrl-C to get out of this logging view. This will tell you also the progress of the blockchain download. When you reach near 0.99 or 1.0 you have downloaded 100% of the blockchain and are 'caught up'
 * As the bitcoin user, you can also use the bitcoin-cli to check: `bitcoin-cli getblockchaininfo`. bitcoin-cli is very powerful tool, have fun exploring it.
 
 🚨 **Please let Bitcoin Core sync fully before proceeding.**

--- a/resources/.bash_aliases
+++ b/resources/.bash_aliases
@@ -125,7 +125,7 @@ alias disableallmain='sudo systemctl disable bitcoind electrs btcrpcexplorer lnd
 # MAIN SERVICES LOGS #
 ######################
 
-alias bitcoindlogs='sudo tail -f /home/bitcoin/.bitcoin/debug.log'
+alias bitcoindlogs='sudo journalctl -f -u bitcoind'
 alias electrslogs='sudo journalctl -f -u electrs'
 alias btcrpcexplorerlogs='sudo journalctl -f -u btcrpcexplorer'
 alias lndlogs='sudo journalctl -f -u lnd'


### PR DESCRIPTION
#### What

With the present configuration, the bitcoind service outputs its log output to a file. This change alters the systemd service definition so that output is sent to stdout which can be managed by systemd journal.

### Why

Having systemd journal manage the log output is more consistent with how logs from other services are managed.

#### How

The `bitcoind.service` file was altered to use an exec process type configuration. Any references to the debug.log file were replaced with the appropriate journal call.

#### Scope

- [x] moderate change to core configuration

#### Test & maintenance

This change can be easily tested by editing the `bitcoind.service` file with the changes, reloading systemd (`sudo systemctl daemon-reload`), and then restarting the bitcoin service (`sudo systemctl restart bitcoind`).

There is no ongoing maintenance.