### PR TITLE
[GUIDE UPDATE] lightning-client - lnd-v0.16.0-beta

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -32,10 +32,10 @@ We'll download, verify and install LND.
 
   ```sh
   $ cd /tmp
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.5-beta/lnd-linux-arm64-v0.15.5-beta.tar.gz
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.5-beta/manifest-v0.15.5-beta.txt
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.5-beta/manifest-roasbeef-v0.15.5-beta.sig
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.15.5-beta/manifest-roasbeef-v0.15.5-beta.sig.ots
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.0-beta/lnd-linux-arm64-v0.16.0-beta.tar.gz
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.0-beta/manifest-v0.16.0-beta.txt
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.0-beta/manifest-guggero-v0.16.0-beta.sig
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.0-beta/manifest-guggero-v0.16.0-beta.sig.ots
   ```
 
 ### Checksum check
@@ -43,8 +43,8 @@ We'll download, verify and install LND.
 * Verify the signed checksum against the actual checksum of your download
 
   ```sh
-  $ sha256sum --check manifest-v0.15.5-beta.txt --ignore-missing
-  > lnd-linux-arm64-v0.15.5-beta.tar.gz: OK
+  $ sha256sum --check manifest-v0.16.0-beta.txt --ignore-missing
+  > lnd-linux-arm64-v0.16.0-beta.tar.gz: OK
   ```
 
 ### Signature check
@@ -54,19 +54,19 @@ Now that we've verified the integrity of the downloaded binary, we need to check
 * Get the public key from the LND developer who signed the manifest file; and add it to your GPG keyring
 
   ```sh
-  $ curl https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/roasbeef.asc | gpg --import
+  $ curl https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/guggero.asc | gpg --import
   > ...
-  > gpg: key 372CBD7633C61696: "Olaoluwa Osuntokun <laolu32@gmail.com>" 1 new signature
+  > gpg: key F4FC70F073100284: "Oliver Gugger <gugger@gmail.com>" 1 new signature
   > ...
   ```
 
 * Verify the signature of the text file containing the checksums for the application
 
   ```sh
-  $ gpg --verify manifest-roasbeef-v0.15.5-beta.sig manifest-v0.15.5-beta.txt
-  > gpg: Signature made Thu Dec  1 11:20:10 2022 PST
-  > gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
-  > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [unknown]
+  $ gpg --verify manifest-guggero-v0.16.0-beta.sig manifest-v0.16.0-beta.txt
+  > gpg:                using RSA key F4FC70F07310028424EFC20A8E4256593F177720
+  > gpg: Good signature from "Oliver Gugger <gugger@gmail.com>"
+  > Primary key fingerprint: F4FC 70F0 7310 0284 24EF  C20A 8E42 5659 3F17 7720
   > [...]
   ```
 
@@ -77,7 +77,7 @@ We can also check that the manifest file was in existence around the time of the
 * Let's verify the timestamp of the file matches the release date.
 
   ```sh
-  $ ots verify manifest-roasbeef-v0.15.5-beta.sig.ots -f manifest-roasbeef-v0.15.5-beta.sig
+  $ ots verify manifest-guggero-v0.16.0-beta.sig.ots -f manifest-guggero-v0.16.0-beta.sig
   > [...]
   > Success! Bitcoin block 765521 attests existence as of 2022-12-01 CET
   ```
@@ -91,10 +91,10 @@ Having verified the integrity and authenticity of the release binary, we can saf
 * Install LND
 
   ```sh
-  $ tar -xzf lnd-linux-arm64-v0.15.5-beta.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.15.5-beta/*
+  $ tar -xzf lnd-linux-arm64-v0.16.0-beta.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.16.0-beta/*
   $ lnd --version
-  > lnd version 0.15.5-beta commit=v0.15.5-beta
+  > lnd version v0.16.0-beta commit=v0.16.0-beta
   ```
 
 ### Data directory
@@ -208,7 +208,6 @@ To improve the security of your wallet, check out these more advanced methods:
   accept-keysend=true
   accept-amp=true
   protocol.wumbo-channels=true
-  protocol.no-anchors=false
   coop-close-target-confs=24
 
   # Watchtower
@@ -219,7 +218,6 @@ To improve the security of your wallet, check out these more advanced methods:
   gc-canceled-invoices-on-the-fly=true
   ignore-historical-gossip-filters=1
   stagger-initial-reconnect=true
-  routing.strictgraphpruning=true
 
   # Database
   [bolt]
@@ -227,8 +225,8 @@ To improve the security of your wallet, check out these more advanced methods:
   db.bolt.auto-compact-min-age=168h
 
   [Bitcoin]
-  bitcoin.active=1
-  bitcoin.mainnet=1
+  bitcoin.active=true
+  bitcoin.mainnet=true
   bitcoin.node=bitcoind
 
   [tor]

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -56,7 +56,7 @@ Now that we've verified the integrity of the downloaded binary, we need to check
   ```sh
   $ curl https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/guggero.asc | gpg --import
   > ...
-  > gpg: key F4FC70F073100284: "Oliver Gugger <gugger@gmail.com>" 1 new signature
+  > gpg: key 8E4256593F177720: "Oliver Gugger <gugger@gmail.com>" 1 new signature
   > ...
   ```
 
@@ -65,7 +65,7 @@ Now that we've verified the integrity of the downloaded binary, we need to check
   ```sh
   $ gpg --verify manifest-guggero-v0.16.0-beta.sig manifest-v0.16.0-beta.txt
   > gpg:                using RSA key F4FC70F07310028424EFC20A8E4256593F177720
-  > gpg: Good signature from "Oliver Gugger <gugger@gmail.com>"
+  > gpg: Good signature from "Oliver Gugger <gugger@gmail.com>" [unknown]
   > Primary key fingerprint: F4FC 70F0 7310 0284 24EF  C20A 8E42 5659 3F17 7720
   > [...]
   ```
@@ -79,7 +79,7 @@ We can also check that the manifest file was in existence around the time of the
   ```sh
   $ ots verify manifest-guggero-v0.16.0-beta.sig.ots -f manifest-guggero-v0.16.0-beta.sig
   > [...]
-  > Success! Bitcoin block 765521 attests existence as of 2022-12-01 CET
+  > Success! Bitcoin block 783050 attests existence as of 2023-03-29 CEST
   ```
 
 * Check that the date of the timestamp is close to the [release date](https://github.com/lightningnetwork/lnd/releases){:target="_blank"} of the LND binary.
@@ -250,7 +250,7 @@ $ lnd
 ```
 Attempting automatic RPC configuration to bitcoind
 Automatically obtained bitcoind's RPC credentials
-2021-11-13 08:16:34.985 [INF] LTND: Version: 0.15.5-beta commit=v0.15.5-beta, build=production, logging=default, debuglevel=info
+2021-11-13 08:16:34.985 [INF] LTND: Version: 0.16.0-beta commit=v0.16.0-beta, build=production, logging=default, debuglevel=info
 2021-11-13 08:16:34.985 [INF] LTND: Active chain: Bitcoin (network=mainnet)
 ...
 2021-11-13 08:16:35.028 [INF] LTND: Waiting for wallet encryption password. Use `lncli create` to create a wallet, `lncli unlock` to unlock an existing wallet, or `lncli changepassword` to change the password of an existing wallet and unlock it.


### PR DESCRIPTION
### What

This PR updates the core guide `lightning-client` (LND) to newly released version `lnd-v0.16.0-beta`. 

Also:  This PR removes some lnd.conf settings which are set to default values and therefore unnecessary to add to lnd.conf. For the sake of consistency, some values are changed from `=1` to `=true`.

### Why

Keeping up with latest developments and improvements (see release-notes).

### How

Tested locally on amd64.

### Scope

- [x] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix


