### PR TITLE
[UPDATE BONUS GUIDE] Lightning Terminal v0.10.0

### DIFF
--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -32,25 +32,18 @@ Table of contents
 
 ## Introduction
 
-Lightning Terminal, developped by Lighining Labs, aims at providing additional tools for LND node operators to manage their node and channel balances. Below is a summary of Lighting Terminal's features:
+Lightning Terminal, developed by Lighining Labs, aims at providing additional tools for LND node operators to manage their node and channel balances. Below is a summary of Lighting Terminal's features:
 
 * Visualize your channel balances in a web GUI
 * Run a single daemon (`litd`) that integrates the Loop (`loopd`), Pool (`poold`) and Faraday (`faraday`) daemons
 * Loop client (`loop`): Perform submarine swaps with the LOOP node using the CLI or web GUI
 * Pool client (`pool`): Buy and sell inbound liquidity using the peer-to-peer auction-based Pool exchange using the CLI or web GUI 
 * Faraday client (`frcli`): Run the Faraday daemon on your node that provides a CLI-based LN node accounting service
+* Automate fee management (alpha)
 
 Because Pool is alpha software, Lightning Terminal is also alpha software.  
 
 ---
-
-## Preparations
-
-### Warning
-
-We will configure Lightning Terminal to use our own LND node. However, when installing Lightning Terminal, it replaces the existing `lncli` binary (the CLI tool that allows us to interact with our LND daemon) with its own version of the `lncli` binary. The Lightining Terminal `lncli` binary is generally an older version and therefore might not have all the functionalities of the `lncli` associated with the version of LND that you're running. 
-
-Just don't be surprised if you want to use a brand new `lncli` command and it does not seem to be recognized! :)
 
 ### Firewall
 
@@ -71,44 +64,53 @@ Just don't be surprised if you want to use a brand new `lncli` command and it do
 
   ```sh
   $ cd /tmp
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.8.1-alpha/lightning-terminal-linux-arm64-v0.8.1-alpha.tar.gz
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.8.1-alpha/manifest-v0.8.1-alpha.txt
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.8.1-alpha/manifest-roasbeef-v0.8.1-alpha.sig
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.9.0-alpha/lightning-terminal-linux-arm64-v0.9.0-alpha.tar.gz
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.9.0-alpha/manifest-v0.9.0-alpha.txt 
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.9.0-alpha/manifest-v0.9.0-alpha.sig
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.9.0-alpha/manifest-v0.9.0-alpha.sig.ots
   ```
 
 * Verify the signed checksum against the actual checksum of your download
 
   ```sh
-  $ sha256sum --check manifest-v0.8.1-alpha.txt --ignore-missing
-  > lightning-terminal-linux-arm64-v0.8.1-alpha.tar.gz: OK
+  $ sha256sum --check manifest-v0.9.0-alpha.txt --ignore-missing
+  > lightning-terminal-linux-arm64-v0.9.0-alpha.tar.gz: OK
   ```
 
-* You should already have Olaoluwa Osuntokun GPG public key from when you installed LND. If not, get the key to verify the manifest file; and add it to your GPG keyring.
+* Get the key to verify the manifest file and add it to your GPG keyring.
 
   ```sh
-  $ curl https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/roasbeef.asc | gpg --import
+  $ gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 26984CB69EB8C4A26196F7A4D7D916376026F177
   > ...
-  > gpg: key 372CBD7633C61696: public key "Olaoluwa Osuntokun <laolu32@gmail.com>" imported
+  > gpg: key D7D916376026F177: public key "Elle Mouton <elle.mouton@gmail.com>" imported
   > ...
   ```
 
 * Verify the signature of the text file containing the checksums for the application
 
   ```sh
-  $ gpg --verify manifest-roasbeef-v0.8.1-alpha.sig manifest-v0.8.1-alpha.txt
-  > gpg: Signature made Sun Oct  9 22:06:52 2022 PDT
-  > gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
-  > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [ultimate]
+  $ gpg --verify manifest-v0.9.0-alpha.sig manifest-v0.9.0-alpha.txt
+  > gpg: Signature made Thu Mar 30 10:04:01 2023 SAST
+  > gpg:                using RSA key 26984CB69EB8C4A26196F7A4D7D916376026F177
+  > gpg: Good signature from "Elle Mouton <elle.mouton@gmail.com>" [ultimate]
   > [...]
+  ```
+  
+* Verify OTS attestations
+
+  ```sh 
+  $ ots verify manifest-v0.9.0-alpha.sig.ots
+  > ...
+  > Success! Bitcoin block 783166 attests existence as of 2023-03-30 CEST
   ```
 
 * Now that the authenticity and integrity of the binary has been proven, unzip the binary and install Lightning Terminal
 
   ```sh
-  $ tar -xzf lightning-terminal-linux-arm64-v0.8.1-alpha.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lightning-terminal-linux-arm64-v0.8.1-alpha/*
+  $ tar -xzf lightning-terminal-linux-arm64-v0.9.0-alpha.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lightning-terminal-linux-arm64-v0.9.0-alpha/*
   $ litd --lnd.version
-  > litd version 0.15.2-beta commit=lightning-terminal-v0.8.1-alpha
+  > litd version 0.16.0-beta commit=lightning-terminal-v0.9.0-alpha
   ```
 
 ### User and data directories
@@ -244,13 +246,35 @@ The settings for Pool, Faraday, Loop can all be put in the configuration file
 
 🔍 *Notice that the options for Faraday, Loop and Pool can be set in this configuration file but you must prefix the software with a dot as we made here. Use samples configuration files shown in github repo of each software for more options*
 
+* Lightning Terminal 0.9.0 requires RPC Middleware to be enabled, therefore we switch to user lnd to adjust `lnd.conf`
+
+  ```sh
+  $ exit
+  $ sudo su - lnd
+  $ nano /data/lnd/lnd.conf
+  ```
+  
+* Append the following at the end of the file (mind that this setting is only available in lnd-0.16.0-beta and newer!)
+
+  ```ini
+  [rpcmiddleware]
+  rpcmiddleware.enable=true
+  ```
+
+* Switch back to user "lit"
+
+  ```sh
+  $ exit
+  $ sudo su - lit
+  ```
+
 ---
 
 ## Run Lightning Terminal
 
 ### Manual start
 
-* Still with user “lit”, we first start Lightning Terminal manually to check if everything works fine.
+* With user "lit", we first start Lightning Terminal manually to check if everything works fine.
 
   ```sh
   $ litd
@@ -480,7 +504,7 @@ If you have installed [Ride The Lightning](../../web-app.md), you can use the Lo
 
   ```sh
   $ litd --lnd.version
-  > litd version 0.15.2-beta commit=lightning-terminal-v0.8.1-alpha
+  > litd version 0.16.0-beta commit=lightning-terminal-v0.9.0-alpha
   ```
 
 * Read the [release notes](https://github.com/lightninglabs/lightning-terminal/releases){:target="_blank"} in case there is any breaking change to be aware of.
@@ -505,7 +529,7 @@ If you have installed [Ride The Lightning](../../web-app.md), you can use the Lo
 
 🚨 Warning: Before uninstalling Lightning Terminal, you might want to make sure that there is no on-going channel leases or LOOP swaps and that you've closed your Pool account. You might also want to make some backup of key files (LSAT token, databases etc) located in the /data directories).
 
-* Stop and disable the systemd service and then delete the service file
+* As "admin", stop and disable the systemd service and then delete the service file
 
   ```sh
   $ sudo systemctl stop litd

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -127,7 +127,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
   ```sh 
   $ ots verify manifest-v$VERSION-alpha.sig.ots
   > ...
-  > Success! Bitcoin block 786978 attests existence as of 2023-04-25 CEST
+  > Success! Bitcoin block 790028 attests existence as of 2023-05-16 CEST
   ```
 
 * Now that the authenticity and integrity of the binary has been proven, unzip the binary and install Lightning Terminal

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -75,7 +75,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 
   ```sh
   $ sha256sum --check manifest-v$VERSION-alpha.txt --ignore-missing
-  > lightning-terminal-linux-arm64-v0.9.1-alpha.tar.gz: OK
+  > Example output: lightning-terminal-linux-arm64-{VERSION}-alpha.tar.gz: OK
   ```
 
 * Get the key to verify the manifest file and add it to your GPG keyring.
@@ -111,7 +111,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
   $ tar -xzf lightning-terminal-linux-arm64-v$VERSION-alpha.tar.gz
   $ sudo install -m 0755 -o root -g root -t /usr/local/bin lightning-terminal-linux-arm64-v$VERSION-alpha/*
   $ litd --lnd.version
-  > litd version 0.16.1-beta commit=lightning-terminal-v0.9.1-alpha
+  > Example Output: litd version {VERSION}-beta commit=lightning-terminal-{VERSION}-alpha
   ```
 
 ### User and data directories
@@ -265,7 +265,6 @@ The settings for Pool, Faraday, Loop can all be put in the configuration file
 * Also if not already present, set `rpclisten` parameter in section `[Application Options]`
 
   ```ini
-  [Application Options]
   rpclisten=0.0.0.0:10009
   ```
   
@@ -520,7 +519,7 @@ If you have installed [Ride The Lightning](../../web-app.md), you can use the Lo
 
   ```sh
   $ litd --lnd.version
-  > litd version 0.16.1-beta commit=lightning-terminal-v0.9.1-alpha
+  > Example output: litd version {VERSION}-beta commit=lightning-terminal-{VERSION}-alpha
   ```
 
 * Read the [release notes](https://github.com/lightninglabs/lightning-terminal/releases){:target="_blank"} in case there is any breaking change to be aware of.

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -50,7 +50,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 * Configure the UFW firewall to allow incoming HTTPS requests:
 
   ```sh
-  $ sudo ufw allow 8443/tcp comment 'allow Lightning Terminal SSL'
+  $ sudo ufw allow 8444/tcp comment 'allow Lightning Terminal SSL'
   $ sudo ufw status
   ```
 

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -63,17 +63,18 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 * With the "admin" user, download the latest arm64 binary and its checksum and verify the integrity of the binary
 
   ```sh
+  $ VERSION="0.9.0"
   $ cd /tmp
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.9.0-alpha/lightning-terminal-linux-arm64-v0.9.0-alpha.tar.gz
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.9.0-alpha/manifest-v0.9.0-alpha.txt 
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.9.0-alpha/manifest-v0.9.0-alpha.sig
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v0.9.0-alpha/manifest-v0.9.0-alpha.sig.ots
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/lightning-terminal-linux-arm64-v$VERSION-alpha.tar.gz
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/manifest-v$VERSION-alpha.txt 
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/manifest-v$VERSIONalpha.sig
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSIONalpha/manifest-v$VERSION-alpha.sig.ots
   ```
 
 * Verify the signed checksum against the actual checksum of your download
 
   ```sh
-  $ sha256sum --check manifest-v0.9.0-alpha.txt --ignore-missing
+  $ sha256sum --check manifest-v$VERSION-alpha.txt --ignore-missing
   > lightning-terminal-linux-arm64-v0.9.0-alpha.tar.gz: OK
   ```
 
@@ -89,7 +90,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 * Verify the signature of the text file containing the checksums for the application
 
   ```sh
-  $ gpg --verify manifest-v0.9.0-alpha.sig manifest-v0.9.0-alpha.txt
+  $ gpg --verify manifest-v$VERSION-alpha.sig manifest-v$VERSION-alpha.txt
   > gpg: Signature made Thu Mar 30 10:04:01 2023 SAST
   > gpg:                using RSA key 26984CB69EB8C4A26196F7A4D7D916376026F177
   > gpg: Good signature from "Elle Mouton <elle.mouton@gmail.com>" [ultimate]
@@ -99,7 +100,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 * Verify OTS attestations
 
   ```sh 
-  $ ots verify manifest-v0.9.0-alpha.sig.ots
+  $ ots verify manifest-v$VERSION-alpha.sig.ots
   > ...
   > Success! Bitcoin block 783166 attests existence as of 2023-03-30 CEST
   ```
@@ -107,8 +108,8 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 * Now that the authenticity and integrity of the binary has been proven, unzip the binary and install Lightning Terminal
 
   ```sh
-  $ tar -xzf lightning-terminal-linux-arm64-v0.9.0-alpha.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lightning-terminal-linux-arm64-v0.9.0-alpha/*
+  $ tar -xzf lightning-terminal-linux-arm64-v$VERSION-alpha.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lightning-terminal-linux-arm64-v$VERSION-alpha/*
   $ litd --lnd.version
   > litd version 0.16.0-beta commit=lightning-terminal-v0.9.0-alpha
   ```

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -471,7 +471,7 @@ Lightning Node Connect allows to connect to Lightning Terminal and the node from
 
 #### How to connect
 
-* Log in to your Lightning Terminal by pasting [https://raspibolt.local:8444/](https://raspibolt.local:8444/){:target="_blank"} in your web browser (replace rapsibolt.local by your node IP address if needed).
+* Log in to your Lightning Terminal by pasting [https://raspibolt.local:8444/](https://raspibolt.local:8444/){:target="_blank"} in your web browser (replace raspibolt.local by your node IP address if needed).
 * In the left menu, click on "Lightning Node Connect"
 * Click on the "Create a new session" button and choose a name (e.g. test #1)
 * Click the "Submit" button, a pairing phrase will be copied to your clipboard

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -88,7 +88,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 * With the "admin" user, download the latest arm64 binary and its checksum and verify the integrity of the binary
 
   ```sh
-  $ VERSION="0.9.1"
+  $ VERSION="0.10.0"
   $ cd /tmp
   $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/lightning-terminal-linux-arm64-v$VERSION-alpha.tar.gz
   $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/manifest-v$VERSION-alpha.txt 

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -272,7 +272,7 @@ The settings for Pool, Faraday, Loop can all be put in the configuration file
 
 🔍 *Notice that the options for Faraday, Loop and Pool can be set in this configuration file but you must prefix the software with a dot as we made here. Use samples configuration files shown in github repo of each software for more options*
 
-* Lightning Terminal 0.9.1 requires RPC Middleware to be enabled, therefore we switch to user lnd to adjust `lnd.conf`
+* Lightning Terminal 0.9.1+ requires RPC Middleware to be enabled, therefore we switch to user lnd to adjust `lnd.conf`
 
   ```sh
   $ exit

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -177,7 +177,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 The Lightning Terminal daemon (`litd`) has its own configuration file. 
 The settings for Pool, Faraday, Loop can all be put in the configuration file 
 
-* Still with the "lit" user, create the configuration file and paste the following content (set the `uipassword` with your password [E] and adjust to your alias; and paste password [B] as required in the Faraday section). Save and exit.
+* Still with the "lit" user, create the configuration file and paste the following content (set the `uipassword` with your password [E] and paste password [B] as required in the Faraday section). Save (Ctrl+o) and exit (Ctrl+x).
 
   ```sh
   $ cd ~/.lit

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -262,6 +262,15 @@ The settings for Pool, Faraday, Loop can all be put in the configuration file
   rpcmiddleware.enable=true
   ```
   
+* Also if not already present, set `rpclisten` parameter in section `[Application Options]`
+
+  ```ini
+  [Application Options]
+  rpclisten=0.0.0.0:10009
+  ```
+  
+* Save (Ctrl+O) and exit (Ctrl+X).
+  
 * Switch to "admin" to restart LND
 
  ```sh

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -260,11 +260,17 @@ The settings for Pool, Faraday, Loop can all be put in the configuration file
   [rpcmiddleware]
   rpcmiddleware.enable=true
   ```
+  
+* Switch to "admin" to restart LND
+
+ ```sh
+ $ exit
+ $ sudo systemctl restart lnd.service
+ ```
 
 * Switch back to user "lit"
 
   ```sh
-  $ exit
   $ sudo su - lit
   ```
 

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -63,19 +63,19 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 * With the "admin" user, download the latest arm64 binary and its checksum and verify the integrity of the binary
 
   ```sh
-  $ VERSION="0.9.0"
+  $ VERSION="0.9.1"
   $ cd /tmp
   $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/lightning-terminal-linux-arm64-v$VERSION-alpha.tar.gz
   $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/manifest-v$VERSION-alpha.txt 
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/manifest-v$VERSIONalpha.sig
-  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSIONalpha/manifest-v$VERSION-alpha.sig.ots
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/manifest-v$VERSION-alpha.sig
+  $ wget https://github.com/lightninglabs/lightning-terminal/releases/download/v$VERSION-alpha/manifest-v$VERSION-alpha.sig.ots
   ```
 
 * Verify the signed checksum against the actual checksum of your download
 
   ```sh
   $ sha256sum --check manifest-v$VERSION-alpha.txt --ignore-missing
-  > lightning-terminal-linux-arm64-v0.9.0-alpha.tar.gz: OK
+  > lightning-terminal-linux-arm64-v0.9.1-alpha.tar.gz: OK
   ```
 
 * Get the key to verify the manifest file and add it to your GPG keyring.
@@ -102,7 +102,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
   ```sh 
   $ ots verify manifest-v$VERSION-alpha.sig.ots
   > ...
-  > Success! Bitcoin block 783166 attests existence as of 2023-03-30 CEST
+  > Success! Bitcoin block 786978 attests existence as of 2023-04-25 CEST
   ```
 
 * Now that the authenticity and integrity of the binary has been proven, unzip the binary and install Lightning Terminal
@@ -111,7 +111,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
   $ tar -xzf lightning-terminal-linux-arm64-v$VERSION-alpha.tar.gz
   $ sudo install -m 0755 -o root -g root -t /usr/local/bin lightning-terminal-linux-arm64-v$VERSION-alpha/*
   $ litd --lnd.version
-  > litd version 0.16.0-beta commit=lightning-terminal-v0.9.0-alpha
+  > litd version 0.16.1-beta commit=lightning-terminal-v0.9.1-alpha
   ```
 
 ### User and data directories
@@ -247,7 +247,7 @@ The settings for Pool, Faraday, Loop can all be put in the configuration file
 
 🔍 *Notice that the options for Faraday, Loop and Pool can be set in this configuration file but you must prefix the software with a dot as we made here. Use samples configuration files shown in github repo of each software for more options*
 
-* Lightning Terminal 0.9.0 requires RPC Middleware to be enabled, therefore we switch to user lnd to adjust `lnd.conf`
+* Lightning Terminal 0.9.1 requires RPC Middleware to be enabled, therefore we switch to user lnd to adjust `lnd.conf`
 
   ```sh
   $ exit
@@ -520,7 +520,7 @@ If you have installed [Ride The Lightning](../../web-app.md), you can use the Lo
 
   ```sh
   $ litd --lnd.version
-  > litd version 0.16.0-beta commit=lightning-terminal-v0.9.0-alpha
+  > litd version 0.16.1-beta commit=lightning-terminal-v0.9.1-alpha
   ```
 
 * Read the [release notes](https://github.com/lightninglabs/lightning-terminal/releases){:target="_blank"} in case there is any breaking change to be aware of.

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -45,13 +45,38 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 
 ---
 
-### Firewall
+### Firewall & Nginx
 
 * Configure the UFW firewall to allow incoming HTTPS requests:
 
   ```sh
   $ sudo ufw allow 8443/tcp comment 'allow Lightning Terminal SSL'
   $ sudo ufw status
+  ```
+
+* Enable NGINX reverse proxy to route external encrypted HTTPS traffic internally to Thunderhub
+
+  ```sh
+  $ sudo nano /etc/nginx/streams-enabled/litd-reverse-proxy.conf
+  ```
+
+* Insert the upstream configuration
+
+  ```nginx
+  upstream litd {
+    server 127.0.0.1:8443;
+  }
+  server {
+    listen 8444 ssl;
+    proxy_pass litd;
+  }
+  ```
+
+* Test and reload NGINX configuration
+
+  ```sh
+  $ sudo nginx -t
+  $ sudo systemctl reload nginx
   ```
 
 ---
@@ -296,7 +321,7 @@ The settings for Pool, Faraday, Loop can all be put in the configuration file
   ```
 
 * Test that Lightning Terminal is working by visiting the web UI
-  * Past the following URL in your browser: [https://raspibolt.local:8443/](https://raspibolt.local::8443/){:target="_blank"} (replace raspibolt.local by your node IP address if required)
+  * Past the following URL in your browser: [https://raspibolt.local:8444/](https://raspibolt.local::8444/){:target="_blank"} (replace raspibolt.local by your node IP address if required)
   * Note that the first time you connect, your browser will display a warning due to the fact the SSL certificate is self-generated. On Firefox, simply click "Advanced" and then "Accept the risks and continue" (or similar wording in other browsers)
   * Enter password [E] when prompted.
   * (Optional) Follow the walkthrough to have a first introduction to Lightning Terminal GUI. Otherwise, click "No thanks" to skip it.
@@ -417,7 +442,7 @@ Rather than always typing the flags, we can create aliases for the "admin" user.
 
 ### Settings
 
-* Log in to your Lightning Terminal by pasting [https://raspibolt.local:8443/](https://raspibolt.local:8443/){:target="_blank"} in your web browser (replace rapsibolt.local by your node IP address if needed).
+* Log in to your Lightning Terminal by pasting [https://raspibolt.local:8444/](https://raspibolt.local:8444/){:target="_blank"} in your web browser (replace rapsibolt.local by your node IP address if needed).
 
 * In the left menu, click on "Settings"
 
@@ -446,7 +471,7 @@ Lightning Node Connect allows to connect to Lightning Terminal and the node from
 
 #### How to connect
 
-* Log in to your Lightning Terminal by pasting [https://raspibolt.local:8443/](https://raspibolt.local:8443/){:target="_blank"} in your web browser (replace rapsibolt.local by your node IP address if needed).
+* Log in to your Lightning Terminal by pasting [https://raspibolt.local:8444/](https://raspibolt.local:8444/){:target="_blank"} in your web browser (replace rapsibolt.local by your node IP address if needed).
 * In the left menu, click on "Lightning Node Connect"
 * Click on the "Create a new session" button and choose a name (e.g. test #1)
 * Click the "Submit" button, a pairing phrase will be copied to your clipboard


### PR DESCRIPTION
### What

Updates the bonus guide "Lightning Terminal" to v0.10.0 
v0.10.0 requires LND version 0.16.2 (!)

### Why

New version, new features (autofees).

### How

Following release docs: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.10.0-alpha

### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [ ] simple bug fix

