### PR TITLE
[UPDATE BONUS GUIDE] Update LNDg to v1.6.3

### DIFF
--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -89,10 +89,22 @@ For that we will create a separate user and we will be running the code as the n
   $ ln -s /data/lnd /home/lndg/.lnd
   ```
 
-* Clone the latest release of the project GitHub repository and enter it
+* Check the version number of the latest LNDg release. You can also confirm with the [release page](https://github.com/cryptosharks131/lndg/releases).
 
   ```sh
-  $ git clone --branch v1.5.0 https://github.com/cryptosharks131/lndg.git
+  $ LATEST_RELEASE=$(wget -qO- https://api.github.com/repos/cryptosharks131/lndg/releases/latest | grep -oP '"tag_name":\s*"\K([^"]+)')
+  $ echo $LATEST_RELEASE
+  > v1.6.3
+  ```
+
+* Clone the release of the project GitHub repository and enter it.
+
+  {: .highlight }
+  > You can also use the latest release (`$LATEST_RELEASE`) if it is higher than the one specified below. However, please be aware that newer releases might not have been thoroughly tested with the rest of the RaspiBolt configuration.
+
+  ```sh
+  $ VERSION=v1.6.3 
+  $ git clone --branch $VERSION https://github.com/cryptosharks131/lndg.git
   $ cd lndg
   ```
   

--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -157,6 +157,12 @@ If you didn't save the password, you can get it again with: `nano /home/lndg/lnd
   $ rm /home/lndg/lndg/data/lndg-admin.txt
   ```
 
+* Exit the "lndg" user session
+
+  ```sh
+  $ exit
+  ```
+
 ### Make the LNDg database easy to backup
 
 LNDg stores the LN node routing statistics and settings in a SQL database. We'll move this database to our data folder to make it easier to archive or backup if desired.
@@ -189,6 +195,13 @@ LNDg stores the LN node routing statistics and settings in a SQL database. We'll
   ```
 
 ### Web server configuration
+
+* Log in with the lndg user and change to lngd directory
+
+  ```sh
+  $ sudo su - lndg
+  $ cd ~/lndg
+  ```
 
 * Install uwsgi within the LNDg Python virtual environment
 


### PR DESCRIPTION
#### What

Update [Bonus Guide LNDg](https://raspibolt.org/guide/bonus/lightning/lndg.html):

1) Update LNDg release to latest version `v1.6.3`.
2) Fix `lndg` user session for section "Make the LNDg database easy to backup".


### Why

1) There is new LNDg release (`v1.6.3`).
2) Unable to complete section "Make the LNDg database easy to backup", while in `lndg` user session .

#### How

1) Update LNDg release to `v1.6.3`.
2) Exit `lndg` user session before section "Make the LNDg database easy to backup", and enter it back after the section.

#### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [x] simple bug fix

Fixes #1263 
