### PR TITLE
Update LND guide to v0.16.1

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -32,10 +32,10 @@ We'll download, verify and install LND.
 
   ```sh
   $ cd /tmp
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.0-beta/lnd-linux-arm64-v0.16.0-beta.tar.gz
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.0-beta/manifest-v0.16.0-beta.txt
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.0-beta/manifest-guggero-v0.16.0-beta.sig
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.0-beta/manifest-guggero-v0.16.0-beta.sig.ots
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.1-beta/lnd-linux-arm64-v0.16.1-beta.tar.gz
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.1-beta/manifest-v0.16.1-beta.txt
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.1-beta/manifest-roasbeef-v0.16.1-beta.sig
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.1-beta/manifest-roasbeef-v0.16.1-beta.sig.ots
   ```
 
 ### Checksum check
@@ -43,8 +43,8 @@ We'll download, verify and install LND.
 * Verify the signed checksum against the actual checksum of your download
 
   ```sh
-  $ sha256sum --check manifest-v0.16.0-beta.txt --ignore-missing
-  > lnd-linux-arm64-v0.16.0-beta.tar.gz: OK
+  $ sha256sum --check manifest-v0.16.1-beta.txt --ignore-missing
+  > lnd-linux-arm64-v0.16.1-beta.tar.gz: OK
   ```
 
 ### Signature check
@@ -54,20 +54,23 @@ Now that we've verified the integrity of the downloaded binary, we need to check
 * Get the public key from the LND developer who signed the manifest file; and add it to your GPG keyring
 
   ```sh
-  $ curl https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/guggero.asc | gpg --import
+  $ curl https://raw.githubusercontent.com/lightningnetwork/lnd/master/scripts/keys/roasbeef.asc | gpg --import
   > ...
-  > gpg: key 8E4256593F177720: "Oliver Gugger <gugger@gmail.com>" 1 new signature
+  > gpg: key 372CBD7633C61696: "Olaoluwa Osuntokun <laolu32@gmail.com>" 1 new signature
   > ...
   ```
 
 * Verify the signature of the text file containing the checksums for the application
 
   ```sh
-  $ gpg --verify manifest-guggero-v0.16.0-beta.sig manifest-v0.16.0-beta.txt
-  > gpg:                using RSA key F4FC70F07310028424EFC20A8E4256593F177720
-  > gpg: Good signature from "Oliver Gugger <gugger@gmail.com>" [unknown]
-  > Primary key fingerprint: F4FC 70F0 7310 0284 24EF  C20A 8E42 5659 3F17 7720
-  > [...]
+  $ gpg --verify manifest-roasbeef-v0.16.1-beta.sig manifest-v0.16.1-beta.txt
+  > gpg: Signature made Tue Apr 25 00:19:24 2023 EEST
+  > gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
+  > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [unknown]
+  > gpg: WARNING: This key is not certified with a trusted signature!
+  > gpg:          There is no indication that the signature belongs to the owner.
+  > Primary key fingerprint: E4D8 5299 674B 2D31 FAA1  892E 372C BD76 33C6 1696
+  >      Subkey fingerprint: 60A1 FA7D A5BF F08B DCBB  E790 3BBD 59E9 9B28 0306
   ```
 
 ### Timestamp check
@@ -77,9 +80,9 @@ We can also check that the manifest file was in existence around the time of the
 * Let's verify the timestamp of the file matches the release date.
 
   ```sh
-  $ ots verify manifest-guggero-v0.16.0-beta.sig.ots -f manifest-guggero-v0.16.0-beta.sig
+  $ ots verify manifest-roasbeef-v0.16.1-beta.sig.ots -f manifest-roasbeef-v0.16.1-beta.sig
   > [...]
-  > Success! Bitcoin block 783050 attests existence as of 2023-03-29 CEST
+  > Success! Bitcoin block 786884 attests existence as of 2023-04-25 EEST
   ```
 
 * Check that the date of the timestamp is close to the [release date](https://github.com/lightningnetwork/lnd/releases){:target="_blank"} of the LND binary.
@@ -91,10 +94,10 @@ Having verified the integrity and authenticity of the release binary, we can saf
 * Install LND
 
   ```sh
-  $ tar -xzf lnd-linux-arm64-v0.16.0-beta.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.16.0-beta/*
+  $ tar -xzf lnd-linux-arm64-v0.16.1-beta.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.16.1-beta/*
   $ lnd --version
-  > lnd version v0.16.0-beta commit=v0.16.0-beta
+  > lnd version v0.16.1-beta commit=v0.16.1-beta
   ```
 
 ### Data directory


### PR DESCRIPTION
#### What

Updates LND guide to newly released v0.16.1.

### Why

Keeping up with latest developments and improvements (see [release notes](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.16.1.md)).

#### Scope

- [X] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix