### PR TITLE
[UPDATE BONUS GUIDE] JoinMarket webui (Jam) v0.1.5

### DIFF
--- a/guide/bonus/bitcoin/Jam.md
+++ b/guide/bonus/bitcoin/Jam.md
@@ -171,10 +171,22 @@ $ sudo su - jam
 $ curl https://dergigi.com/PGP.txt | gpg --import
 ```
 
+* Check the latest Jam release version. You can also confirm with the [release page](https://github.com/joinmarket-webui/jam/releases){:target="_blank" rel="noopener"}
+
+  ```sh
+  $ LATEST_RELEASE=$(wget -qO- https://api.github.com/repos/joinmarket-webui/jam/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+  $ echo $LATEST_RELEASE
+  ```
+
 * Retrieve source code
 
+  {: .highlight }
+  > You can also use the latest release (`$LATEST_RELEASE`). However, please be aware that newer releases might not have been thoroughly tested with the rest of the RaspiBolt configuration.
+
+
 ```sh
-$ git clone https://github.com/joinmarket-webui/jam.git --branch v0.1.4 --depth=1
+$ RELEASE="v0.1.5"
+$ git clone https://github.com/joinmarket-webui/jam.git --branch $RELEASE --depth=1
 ```
 
 * Verify release by looking for `Good signature` response
@@ -182,7 +194,7 @@ $ git clone https://github.com/joinmarket-webui/jam.git --branch v0.1.4 --depth=
 ```sh
 $ cd jam
 
-$ git verify-tag v0.1.4
+$ git verify-tag $RELEASE
 ...
 > gpg: Good signature from "Gigi <dergigi@pm.me>" [unknown]
 > gpg: WARNING: This key is not certified with a trusted signature!

--- a/guide/bonus/bitcoin/Jam.md
+++ b/guide/bonus/bitcoin/Jam.md
@@ -174,19 +174,19 @@ $ curl https://dergigi.com/PGP.txt | gpg --import
 * Check the latest Jam release version. You can also confirm with the [release page](https://github.com/joinmarket-webui/jam/releases){:target="_blank" rel="noopener"}
 
   ```sh
-  $ LATEST_RELEASE=$(wget -qO- https://api.github.com/repos/joinmarket-webui/jam/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
-  $ echo $LATEST_RELEASE
+  $ LATEST_VERSION=$(wget -qO- https://api.github.com/repos/joinmarket-webui/jam/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+  $ echo $LATEST_VERSION
   ```
 
 * Retrieve source code
 
   {: .highlight }
-  > You can also use the latest release (`$LATEST_RELEASE`). However, please be aware that newer releases might not have been thoroughly tested with the rest of the RaspiBolt configuration.
+  > You can also use the latest release version (`$LATEST_VERSION`). However, please be aware that newer releases might not have been thoroughly tested with the rest of the RaspiBolt configuration.
 
 
 ```sh
-$ RELEASE="v0.1.5"
-$ git clone https://github.com/joinmarket-webui/jam.git --branch $RELEASE --depth=1
+$ VERSION="v0.1.5"
+$ git clone https://github.com/joinmarket-webui/jam.git --branch $VERSION --depth=1
 ```
 
 * Verify release by looking for `Good signature` response
@@ -194,7 +194,7 @@ $ git clone https://github.com/joinmarket-webui/jam.git --branch $RELEASE --dept
 ```sh
 $ cd jam
 
-$ git verify-tag $RELEASE
+$ git verify-tag $VERSION
 ...
 > gpg: Good signature from "Gigi <dergigi@pm.me>" [unknown]
 > gpg: WARNING: This key is not certified with a trusted signature!

--- a/guide/bonus/bitcoin/Jam.md
+++ b/guide/bonus/bitcoin/Jam.md
@@ -179,8 +179,8 @@ $ echo $LATEST_VERSION
 
 * Retrieve source code
 
-  {: .highlight }
-  > You can also use the latest release version (`$LATEST_VERSION`). However, please be aware that newer releases might not have been thoroughly tested with the rest of the RaspiBolt configuration.
+{: .highlight }
+> You can also use the latest release version (`$LATEST_VERSION`). However, please be aware that newer releases might not have been thoroughly tested with the rest of the RaspiBolt configuration.
 
 
 ```sh

--- a/guide/bonus/bitcoin/Jam.md
+++ b/guide/bonus/bitcoin/Jam.md
@@ -176,6 +176,7 @@ $ curl https://dergigi.com/PGP.txt | gpg --import
 ```sh
 $ LATEST_VERSION=$(wget -qO- https://api.github.com/repos/joinmarket-webui/jam/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
 $ echo $LATEST_VERSION
+```
 
 * Retrieve source code
 

--- a/guide/bonus/bitcoin/Jam.md
+++ b/guide/bonus/bitcoin/Jam.md
@@ -358,7 +358,7 @@ $ sudo nano /etc/tor/torrc
 # Hidden Service Jam
 HiddenServiceDir /var/lib/tor/hidden_service_jam/
 HiddenServiceVersion 3
-HiddenServicePort 80 127.0.0.1:4020
+HiddenServicePort 443 127.0.0.1:4020
 ```
 
 * Reload Tor configuration and get your connection address.
@@ -431,7 +431,7 @@ $ sudo nano /etc/tor/torrc
 # Hidden Service Jam
 #HiddenServiceDir /var/lib/tor/hsv3/
 #HiddenServiceVersion 3
-#HiddenServicePort 80 127.0.0.1:4020
+#HiddenServicePort 443 127.0.0.1:4020
 ```
 
 ```sh

--- a/guide/bonus/bitcoin/Jam.md
+++ b/guide/bonus/bitcoin/Jam.md
@@ -173,10 +173,9 @@ $ curl https://dergigi.com/PGP.txt | gpg --import
 
 * Check the latest Jam release version. You can also confirm with the [release page](https://github.com/joinmarket-webui/jam/releases){:target="_blank" rel="noopener"}
 
-  ```sh
-  $ LATEST_VERSION=$(wget -qO- https://api.github.com/repos/joinmarket-webui/jam/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
-  $ echo $LATEST_VERSION
-  ```
+```sh
+$ LATEST_VERSION=$(wget -qO- https://api.github.com/repos/joinmarket-webui/jam/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+$ echo $LATEST_VERSION
 
 * Retrieve source code
 


### PR DESCRIPTION
#### What

1. Update Bonus guide: JoinMarket webui (Jam) to v0.1.5.
2.  Fix Tor port (change from 80 to 443).


### Why

1. New [Jam release version v0.1.5](https://github.com/joinmarket-webui/jam/releases).
2. Jam is listening on SSL port (4020), hence Tor should listen on and forward port 443 rather than 80.


#### How

[Bonus guide: JoinMarket webui (Jam)](https://raspibolt.org/guide/bonus/bitcoin/Jam.html#bonus-guide-joinmarket-webui-jam) has been updated.

#### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Tested with Jam v0.1.5.