### PR TITLE
fix typo within lncli field in guide to close a lightning channel

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -698,7 +698,7 @@ A quick reference with common commands to play around with:
   $ lncli listinvoices
   ```
 
-* to close a channel, you need the following two arguments that can be determined with `listchannels` and are listed as "channelpoint": `FUNDING_TXID`:`OUTPUT_INDEX`
+* to close a channel, you need the following two arguments that can be determined with `listchannels` and are listed as "channel_point": `FUNDING_TXID`:`OUTPUT_INDEX`
 
   [`closechannel`](https://api.lightning.community/api/lnd/lightning/close-channel){:target="_blank"}
 


### PR DESCRIPTION
#### What

Typo in field of expected lncli response of listchannels.

The correct field is shown in the LND API Reference here:
https://api.lightning.community/api/lnd/lightning/list-channels#lnrpcchannel

### Why

Grepping for the incorrect field in the lncli response comes back empty.

#### How

Correction to the expected field.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance
Start with a lightning node with some active channels.
run: `lncli listchannels | grep channel_point`
channel_point field info is returned.