### PR TITLE
Fixes raspibolt/raspibolt#1282

### DIFF
--- a/guide/bonus/raspberry-pi/command-line.md
+++ b/guide/bonus/raspberry-pi/command-line.md
@@ -39,7 +39,7 @@ $ nano /home/admin/.bashrc
 force_color_prompt=yes
 
 # pimp prompt (comment/replace the PS1 line)
-PS1="${debian_chroot:+($debian_chroot)}\[\e[33m\]\u \[\033[01;34m\]\w\[\e[33;40m\] ₿\[\e[m\] "
+PS1="${debian_chroot:+($debian_chroot)}\[\e[33m\]\u \[\033[01;34m\]\w\[\e[33m\] ₿\[\e[m\] "
 
 # set "ls" to always use the -la option, to list details of all files (including hidden), as default
 # simply insert the following line at the end of the file, or replace existing "alias ls='ls --color=auto'" if already present in the "enable color support of ls" section


### PR DESCRIPTION
#### What

Proposal to fix the issue raspibolt/raspibolt#1282

### Why

It's not important, but it looks a little bit nicer :-)

#### How

Removed the black background color within the PS1 variable.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix

Fixes raspibolt/raspibolt#1282

#### Test & maintenance

- As soon the updated script is installed, the bug is fixed.
- This should not need any further maintenance.