### PR TITLE
shorten the menu separators on the website

### DIFF
--- a/guide/bonus-section-separator.md
+++ b/guide/bonus-section-separator.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: __________________________
+title: ____________________
 nav_order: 99
 ---
 <meta http-equiv="refresh" content="0; URL=bonus/">

--- a/guide/troubleshooting-separator.md
+++ b/guide/troubleshooting-separator.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: __________________________
+title: ____________________
 nav_order: 199
 ---
 <meta http-equiv="refresh" content="0; URL=troubleshooting.html">


### PR DESCRIPTION
#### What

shorten the menu separators on the website

### Why

looks better on the website

#### How

shortened the separator lines from 26 to 20 chars

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix

Fixes raspibolt/raspibolt#1285

#### Test & maintenance

Did not know how to test this locally.