### PR TITLE
Update LND guide to v0.16.3

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -32,10 +32,10 @@ We'll download, verify and install LND.
 
   ```sh
   $ cd /tmp
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.2-beta/lnd-linux-arm64-v0.16.2-beta.tar.gz
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.2-beta/manifest-v0.16.2-beta.txt
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.2-beta/manifest-roasbeef-v0.16.2-beta.sig
-  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.2-beta/manifest-roasbeef-v0.16.2-beta.sig.ots
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.3-beta/lnd-linux-arm64-v0.16.3-beta.tar.gz
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.3-beta/manifest-v0.16.3-beta.txt
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.3-beta/manifest-roasbeef-v0.16.3-beta.sig
+  $ wget https://github.com/lightningnetwork/lnd/releases/download/v0.16.3-beta/manifest-roasbeef-v0.16.3-beta.sig.ots
   ```
 
 ### Checksum check
@@ -43,8 +43,8 @@ We'll download, verify and install LND.
 * Verify the signed checksum against the actual checksum of your download
 
   ```sh
-  $ sha256sum --check manifest-v0.16.2-beta.txt --ignore-missing
-  > lnd-linux-arm64-v0.16.1-beta.tar.gz: OK
+  $ sha256sum --check manifest-v0.16.3-beta.txt --ignore-missing
+  > lnd-linux-arm64-v0.16.3-beta.tar.gz: OK
   ```
 
 ### Signature check
@@ -63,8 +63,8 @@ Now that we've verified the integrity of the downloaded binary, we need to check
 * Verify the signature of the text file containing the checksums for the application
 
   ```sh
-  $ gpg --verify manifest-roasbeef-v0.16.2-beta.sig manifest-v0.16.2-beta.txt
-  > gpg: Signature made Fri Apr 28 23:41:50 2023 EEST
+  $ gpg --verify manifest-roasbeef-v0.16.3-beta.sig manifest-v0.16.3-beta.txt
+  > gpg: Signature made Tue Jun  6 04:57:08 2023 EEST
   > gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
   > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [unknown]
   > gpg: WARNING: This key is not certified with a trusted signature!
@@ -80,9 +80,9 @@ We can also check that the manifest file was in existence around the time of the
 * Let's verify the timestamp of the file matches the release date.
 
   ```sh
-  $ ots verify manifest-roasbeef-v0.16.2-beta.sig.ots -f manifest-roasbeef-v0.16.2-beta.sig
+  $ ots verify manifest-roasbeef-v0.16.3-beta.sig.ots -f manifest-roasbeef-v0.16.3-beta.sig
   > [...]
-  > Success! Bitcoin block 787408 attests existence as of 2023-04-29 EEST
+  > Success! Bitcoin block 793048 attests existence as of 2023-06-06 EEST
   ```
 
 * Check that the date of the timestamp is close to the [release date](https://github.com/lightningnetwork/lnd/releases){:target="_blank"} of the LND binary.
@@ -94,8 +94,8 @@ Having verified the integrity and authenticity of the release binary, we can saf
 * Install LND
 
   ```sh
-  $ tar -xzf lnd-linux-arm64-v0.16.2-beta.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.16.2-beta/*
+  $ tar -xzf lnd-linux-arm64-v0.16.3-beta.tar.gz
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.16.3-beta/*
   $ lnd --version
   > lnd version v0.16.2-beta commit=v0.16.2-beta
   ```

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -97,7 +97,7 @@ Having verified the integrity and authenticity of the release binary, we can saf
   $ tar -xzf lnd-linux-arm64-v0.16.3-beta.tar.gz
   $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v0.16.3-beta/*
   $ lnd --version
-  > lnd version v0.16.2-beta commit=v0.16.2-beta
+  > lnd version v0.16.3-beta commit=v0.16.3-beta
   ```
 
 ### Data directory


### PR DESCRIPTION
#### What

Updates LND guide to newly released v0.16.3.

### Why

Keeping up with latest developments and improvements (see [release notes](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.16.3.md)).

#### Scope

- [X] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix