### PR TITLE
RTL: Print version you are upgrading to when upgrading

### DIFF
--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -298,7 +298,7 @@ Make sure to read the release notes first.
   $ cd /home/rtl/RTL
   $ git fetch
   $ git reset --hard
-  $ latest=$(git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1)
+  $ latest=$(git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1); echo $latest
   $ git checkout $latest
   $ git verify-tag $latest
   $ npm install --omit=dev --legacy-peer-deps


### PR DESCRIPTION
#### What

Print version you are upgrading to when upgrading.

### Why

It is useful feedback. Currently you don't know to which version you are actually upgrading. You are just blindly assuming that `git tag...` oneliner does the magic.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix