### PR TITLE
[docs update] Update Fulcrum index size info

### DIFF
--- a/guide/bonus/bitcoin/fulcrum.md
+++ b/guide/bonus/bitcoin/fulcrum.md
@@ -36,7 +36,7 @@ Table of contents
 ## Requirements
 
 * Bitcoin Core
-* Little over 100GB of free storage for database (external backup recommended)
+* Storage space for database (external backup recommended); currently takes up 133GB (as of Aug 2023).
 
 ---
 


### PR DESCRIPTION
#### What

Guideline for Fulcrum storage requirements is out of date.

current `du`
```
30M	/fulcrum_data/blkinfo
17G	/fulcrum_data/txhash2txnum
10G	/fulcrum_data/utxoset
5.6G	/fulcrum_data/scripthash_unspent
165M	/fulcrum_data/undo
4.6M	/fulcrum_data/meta
69G	/fulcrum_data/scripthash_history
128G	/fulcrum_data
```

(actually a tiny bit smaller than the last time I ran it, but close enough)

Also see: https://github.com/cculianu/Fulcrum/pull/194

### Why

Fulcrum indexing takes forever AND is quite fragile; if you don't allocate the proper size disk / partition, the process could crash and corrupt the DB, forcing you to start from the beginning (ask me how I know!! Twice!!).

#### How

The power of a text editor.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix
- [x] simple documentation update

Fixes # (link issue)

#### Test & maintenance

Periodically revise the storage requirements... annually? Guesstimate that it's growing at 20GB/yr.

#### Animated GIF (optional)

_Add some snazz if you feel like it :)_

#nosnazz
