### PR TITLE
create home folders as 0755 on Debian 12

### DIFF
--- a/guide/bitcoin/blockchain-explorer.md
+++ b/guide/bitcoin/blockchain-explorer.md
@@ -116,7 +116,7 @@ An attacker would not be able to do much within this user's permission settings.
 * Create a new user, assign it to the "bitcoin" group, and open a new session
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" btcrpcexplorer
+  $ sudo adduser --system --group --shell /bin/bash --home /home/btcrpcexplorer btcrpcexplorer
   $ sudo adduser btcrpcexplorer bitcoin
   $ sudo su - btcrpcexplorer
   ```

--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -129,7 +129,7 @@ We get the latest release of the Electrs source code, verify it, compile it to a
 * Create the "electrs" service user, and make it a member of the "bitcoin" group
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" electrs
+  $ sudo adduser --system --group --shell /bin/bash --home /home/electrs electrs
   $ sudo adduser electrs bitcoin
   ```
 

--- a/guide/bonus/bitcoin/Jam.md
+++ b/guide/bonus/bitcoin/Jam.md
@@ -160,7 +160,7 @@ $ sudo ufw status
 * Create a dedicated user for Jam and switch to user
 
 ```sh
-$ sudo adduser --disabled-password --gecos "" jam
+$ sudo adduser --system --group --shell /bin/bash --home /home/jam jam
 
 $ sudo su - jam
 ```

--- a/guide/bonus/bitcoin/dojo.md
+++ b/guide/bonus/bitcoin/dojo.md
@@ -235,7 +235,7 @@ If you are using Electrs instead of Fulcrum, it is necessary to make following c
 * Create the user "dojo" and add him to the group “bitcoin” as well
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" dojo
+  $ sudo adduser --system --group --shell /bin/bash --home /home/dojo dojo
   $ sudo adduser dojo bitcoin
   ```
 

--- a/guide/bonus/bitcoin/fulcrum.md
+++ b/guide/bonus/bitcoin/fulcrum.md
@@ -236,7 +236,7 @@ Now that Fulcrum is installed, we need to configure it to run automatically on s
 * Create the "fulcrum" service user, and add it to "bitcoin" group
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" fulcrum
+  $ sudo adduser --system --group --shell /bin/bash --home /home/fulcrum fulcrum
   $ sudo adduser fulcrum bitcoin
   ```
 

--- a/guide/bonus/bitcoin/joinmarket.md
+++ b/guide/bonus/bitcoin/joinmarket.md
@@ -61,7 +61,7 @@ If you get `E: Package 'python-virtualenv' has no installation candidate` error 
 * Create the “joinmarket” user, and make it a member of the “bitcoin” and "debian-tor" groups
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" joinmarket
+  $ sudo adduser --system --group --shell /bin/bash --home /home/joinmarket joinmarket
   $ sudo usermod -a -G bitcoin,debian-tor joinmarket
   ```
 

--- a/guide/bonus/bitcoin/mempool.md
+++ b/guide/bonus/bitcoin/mempool.md
@@ -78,7 +78,7 @@ For improved security, we create the new user "mempool" that will run the Mempoo
 * Create a new user, assign it to the "bitcoin" group, and open a new session
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" mempool
+  $ sudo adduser --system --group --shell /bin/bash --home /home/mempool mempool
   $ sudo adduser mempool bitcoin
   $ sudo su - mempool
   ```

--- a/guide/bonus/bitcoin/specter-desktop.md
+++ b/guide/bonus/bitcoin/specter-desktop.md
@@ -80,7 +80,7 @@ These instructions will clone the repo to fetch the latest version and then "pip
 
 - Create a new user, add it to the bitcoin group and open a new session
   ```sh
-  $ sudo adduser --disabled-password --gecos "" specter
+  $ sudo adduser --system --group --shell /bin/bash --home /home/specter specter
   $ sudo adduser specter bitcoin
   $ sudo su - specter
   ```

--- a/guide/bonus/lightning/ambossping.md
+++ b/guide/bonus/lightning/ambossping.md
@@ -45,7 +45,7 @@ Table of contents
 * With user “admin”, create a new user “ambossping” and make it a member of the “lnd” group
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" ambossping
+  $ sudo adduser --system --group --shell /bin/bash --home /home/ambossping ambossping
   $ sudo adduser ambossping lnd
   ```
 

--- a/guide/bonus/lightning/balance-of-satoshis.md
+++ b/guide/bonus/lightning/balance-of-satoshis.md
@@ -57,7 +57,7 @@ Table of contents
 * Create a new user "bos" and make it a member of the "lnd" group
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" bos
+  $ sudo adduser --system --group --shell /bin/bash --home /home/bos bos
   $ sudo adduser bos lnd
   $ sudo su - bos
   ```

--- a/guide/bonus/lightning/charge-lnd.md
+++ b/guide/bonus/lightning/charge-lnd.md
@@ -79,7 +79,7 @@ Table of contents
 * With user "admin", create a new user "chargelnd" and make it a member of the "lnd" group
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" chargelnd
+  $ sudo adduser --system --group --shell /bin/bash --home /home/chargelnd chargelnd
   $ sudo adduser chargelnd lnd
   ```
 

--- a/guide/bonus/lightning/circuit-breaker.md
+++ b/guide/bonus/lightning/circuit-breaker.md
@@ -50,7 +50,7 @@ Table of contents
 * Create a new user "circuitbreaker" and make it part of the "lnd" group
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" circuitbreaker
+  $ sudo adduser --system --group --shell /bin/bash --home /home/circuitbreaker circuitbreaker
   $ sudo adduser circuitbreaker lnd
   ```
  

--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -55,7 +55,7 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
 * As "admin", create a new user named "lightningd" and add it to groups "bitcoin" and "debian-tor". Also add "admin" to group "lightningd" for later use.
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" lightningd
+  $ sudo adduser --system --group --shell /bin/bash --home /home/lightningd lightningd
   $ sudo usermod -a -G bitcoin,debian-tor lightningd
   $ sudo adduser admin lightningd
   ```

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -144,7 +144,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 * Create the “lit” service user, and make it a member of the “bitcoin” and “lnd” groups
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" lit
+  $ sudo adduser --system --group --shell /bin/bash --home /home/lit lit
   $ sudo usermod -a -G bitcoin,lnd lit
   ```
 

--- a/guide/bonus/lightning/lnbits.md
+++ b/guide/bonus/lightning/lnbits.md
@@ -89,7 +89,7 @@ Table of contents
 * Create a new user and add it to the "lnd" group.
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" lnbits
+  $ sudo adduser --system --group --shell /bin/bash --home /home/lnbits lnbits
   $ sudo adduser lnbits lnd
   ```
 

--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -76,7 +76,7 @@ For that we will create a separate user and we will be running the code as the n
 * Create a new user and make it a member of the "lnd" group to give it read access to the LND macaroons and data
   
   ```sh
-  $ sudo adduser --disabled-password --gecos "" lndg
+  $ sudo adduser --system --group --shell /bin/bash --home /home/lndg lndg
   $ sudo adduser lndg lnd
   $ sudo adduser lndg www-data
   $ sudo adduser www-data lndg

--- a/guide/bonus/lightning/rebalance-lnd.md
+++ b/guide/bonus/lightning/rebalance-lnd.md
@@ -65,7 +65,7 @@ pip is not installed by default on Raspberry Pi OS Lite (64-bit), check if it is
 * We create a "rebalance-lnd" user and we make it part of the "bitcoin" group (to be able to interact with LND)
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" rebalance-lnd
+  $ sudo adduser --system --group --shell /bin/bash --home /home/rebalance-lnd rebalance-lnd
   $ sudo adduser rebalance-lnd lnd
   ```
 

--- a/guide/bonus/lightning/regolancer.md
+++ b/guide/bonus/lightning/regolancer.md
@@ -51,7 +51,7 @@ Table of contents
 * With user “admin”, create a new user “regolancer” and make it a member of the “lnd” group
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" regolancer
+  $ sudo adduser --system --group --shell /bin/bash --home /home/regolancer regolancer
   $ sudo adduser regolancer lnd
   ```
 

--- a/guide/bonus/lightning/thunderhub.md
+++ b/guide/bonus/lightning/thunderhub.md
@@ -90,7 +90,7 @@ We are going to install Thunderhub in the home directory since it doesn't need t
 * Create a new "thunderhub" user. The new user needs read-only access to the `tls.cert` and our `admin.macaroon`, so we add him to the "lnd" group. Open a new session.
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" thunderhub
+  $ sudo adduser --system --group --shell /bin/bash --home /home/thunderhub thunderhub
   $ sudo adduser thunderhub lnd
   $ sudo cp /data/lnd/data/chain/bitcoin/mainnet/admin.macaroon /home/thunderhub/admin.macaroon
   $ sudo chown thunderhub:thunderhub /home/thunderhub/admin.macaroon

--- a/guide/bonus/raspberry-pi/homer.md
+++ b/guide/bonus/raspberry-pi/homer.md
@@ -71,7 +71,7 @@ This guide assumes that you have followed the main RaspiBolt guide and installed
 * Create the "homer" service user, create the data directory and open a new session 
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" homer
+  $ sudo adduser --system --group --shell /bin/bash --home /home/homer homer
   $ sudo mkdir /data/homer
   $ sudo chown homer:homer /data/homer
   $ sudo su - homer

--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -108,7 +108,7 @@ Now that LND is installed, we need to configure it to work with Bitcoin Core and
 * Create the "lnd" service user, and add it to the groups "bitcoin" and "debian-tor"
 
   ```sh
-  $ sudo adduser --disabled-password --gecos "" lnd
+  $ sudo adduser --system --group --shell /bin/bash --home /home/lnd lnd
   $ sudo usermod -a -G bitcoin,debian-tor lnd
   ```
 

--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -82,7 +82,7 @@ We do not want to run Ride the Lightning alongside bitcoind and lnd because of s
 
 * Create a new user, copy the LND credentials and open a new session
   ```sh
-  $ sudo adduser --disabled-password --gecos "" rtl
+  $ sudo adduser --system --group --shell /bin/bash --home /home/rtl rtl
   $ sudo cp /data/lnd/data/chain/bitcoin/mainnet/admin.macaroon /home/rtl/admin.macaroon
   $ sudo chown rtl:rtl /home/rtl/admin.macaroon
   $ sudo su - rtl


### PR DESCRIPTION
#### What
Adding changes in Raspibolt as well because the user creation command in Raspiblitz was originating from here, but now needs to be changed.

Changing the user creation in every script from:
```
sudo adduser --disabled-password --gecos "" ${APPID}
```
to
```
sudo adduser --system  --shell /bin/bash --group --home /home/${APPID} ${APPID}
```
These changes are required because of the change in the default permissions in Debian 12. 
Tested the commands work to the same effect on Debian11 as well.

### Why

See the permission issues documented in: https://github.com/raspiblitz/raspiblitz/issues/4154

#### How
`man adduser`:
>If called with one non-option argument and the --system option, adduser will add a dynamically allocated
       system user, often abbreviated as system user in the context of the adduser package.
       By  default,  system  users are placed in the nogroup group.  To place the new system user in an already
       existing group, use the --gid or --ingroup options.  If the --group is given and the  identically  named
       group does not already exist, it is created with the same ID.
       If  no  home  directory  is specified, the default home directory for a new system user is /nonexistent.
       This directory should never exist on any Debian system, and adduser will never create it automatically.

`man adduser.conf`
>DIR_MODE
              The  permissions  mode  for  home directories of non-system users that are created by adduser(8).
              Defaults to 0700.  Note that there are potential configurations (such as /~user web services,  or
              in-home mail delivery) which will require changes to the default.  See also SYS_DIR_MODE.

>SYS_DIR_MODE
              The  permissions  mode  for home directories of system users that are created by adduser(8).  De‐
              faults to 0755.  Note that changing the default permissions for system users may cause some pack‐
              ages to behave unreliably, if the program relies on the default setting.  See also DIR_MODE.

#### Scope

- [x] significant change to core configuration

#### Test & maintenance
Create users on Debian 11 and Debian 12
Compare the permissions in:
```
ls -la /home
```