### PR TITLE
Generate CLN QR code image in PNG format instead of UTF-8

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -606,7 +606,7 @@ The Zeus mobile app will access the node via Tor.
 * Save the QR code as an image:
 
   ```sh
-  $ qrencode -t utf8 -r cln-qr-code-template.txt -o cln-qr-code.png
+  $ qrencode -t png -r cln-qr-code-template.txt -o cln-qr-code.png
   $ chmod 644 cln-qr-code.png
   ```
 


### PR DESCRIPTION
#### What

After reviewing these instructions, when I downloaded the QR code image to view it on another image preview client, the image is broken because it is in UTF-8 format instead of PNG. 

### Why

The image should be viewable as a PNG in places other than the command line.

#### How

Changing the `-t` parameter of `qrencode` to specify `png` instead of `utf8`.

#### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [x] simple bug fix

Fixes # (link issue)

#### Test & maintenance

How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?

Generate the QR code on the Raspibolt, download it to another machine and open it up an an image viewer.

#### Animated GIF (optional)

Add some snazz if you feel like it :)

#nosnazz
