### PR TITLE
CLN REST certs upgrade note

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -292,6 +292,7 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
 * Upgrade CLN with care and follow the instructions on CLN repository completely to understand the changes.
 * Remove the git repository or `git pull` from within and redo the verification and building steps as described above.
 * Verify with `lightning-cli --version` that the update applied.
+* It is likely necessary to update the `c-lightning-REST` plugin as well. Don't forget to copy the `certs` directory from your prior plugin installation to the new one in order to preserve the access credentials.
 * Restart the systemd service for the update to take effect and reload configuration.
 
   ```sh


### PR DESCRIPTION
CLN REST certs upgrade note

#### What

When upgrading CLN REST plugin, user will need to copy over their prior `certs` directory in order to preserve the access credentials. Otherwise client apps like Zeus will lose connectivity.

### Why

Should be a helpful reminder to acknowledge CLN version and CLN REST versions are functionally related, probably upgraded together, and a manual port of credentials / certs is necessary because of the tarball install method in CLN REST documentation.

#### How

How was this change accomplished?

Upgraded and lost access, fixed and updated docs.

#### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [ ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?

Peform an upgrade and make sure RTL and Zeus still connect.

#### Animated GIF (optional)

Add some snazz if you feel like it :)

#nosnazz