### PR TITLE
[bugfix] LNbits: systemd - add missing section header unit

### DIFF
--- a/guide/bonus/lightning/lnbits.md
+++ b/guide/bonus/lightning/lnbits.md
@@ -241,6 +241,7 @@ Your browser will display a warning because we use a self-signed SSL certificate
   # RaspiBolt: systemd unit for LNbits
   # /etc/systemd/system/lnbits.service
 
+  [Unit]
   Description=LNbits
   After=lnd.service
   PartOf=lnd.service


### PR DESCRIPTION
#### What

Bug reported in RaspiBolt TG group: https://t.me/raspibolt/22052

### Why

Missing section header causes systemd service issues.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix
