### PR TITLE
[bugfix] LiT: nginx - remove ssl option

### DIFF
--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -67,7 +67,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
     server 127.0.0.1:8443;
   }
   server {
-    listen 8444 ssl;
+    listen 8444;
     proxy_pass litd;
   }
   ```


### PR DESCRIPTION
#### What

Fixing a bug reported on RaspiBolt TG group: https://t.me/raspibolt/22083

### Why

Make Things Work Again

#### How

LiT exposes httpslisten itself, so nginx does not have to terminate SSL here. 
Therefore we remove this option in the nginx config file.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix
