### PR TITLE
[UPDATE BONUS GUIDE] CLN 23.08.1, c-lightning-rest 0.10.7, RTL 0.14.1config

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -104,14 +104,14 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   $ git clone https://github.com/ElementsProject/lightning.git
   $ cd lightning
   $ git fetch --all --tags
-  $ git checkout v23.08
+  $ git checkout v23.08.1
   ``` 
 
 * Don't trust, verify! Check who released the current version and get their signing keys and verify checksums. Verification step should output `Good Signature`.
 
   ```sh
   $ curl https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/rustyrussell.txt | gpg --import
-  $ git verify-tag v23.08
+  $ git verify-tag v23.08.1
   ```
 
 * Download user specific python packages.


### PR DESCRIPTION
### What

This PR updates bonus guide CLN (+ c-lightning-rest) to their latest versions: cln 23.08.1 and cln-rest v0.10.7.

### Why

Keeping CLN updated and playing with many new (experimental) features: anchors, dual-fund

#### How

Tested locally on amd64

#### Scope

- [ ] significant change to core configuration
- [x] updating independent bonus guide
- [ ] simple bug fix
