### PR TITLE
[UPDATE BONUS GUIDE] LNDg: update to v1.8.0

### DIFF
--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -277,7 +277,7 @@ LNDg stores the LN node routing statistics and settings in a SQL database. We'll
   Description=LNDg uWSGI app
   After=lnd.service
   PartOf=lnd.service
-  Wants=controller-lndg.service
+  Wants=lndg-controller.service
   
   [Service]
   ExecStart=/home/lndg/lndg/.venv/bin/uwsgi --ini /home/lndg/lndg/lndg.ini
@@ -466,12 +466,12 @@ To have updated information in the GUI, it is necessary to regularly run the scr
 * Create a systemd service file to run the LNDg `controller.py` Python script. Save (Ctrl+o) and exit (Ctrl+x).
 
   ```sh
-  $ sudo nano /etc/systemd/system/controller-lndg.service
+  $ sudo nano /etc/systemd/system/lndg-controller.service
   ```
 
   ```ini
   # RaspiBolt: systemd unit for LNDg
-  # /etc/systemd/system/controller-lndg.service
+  # /etc/systemd/system/lndg-controller.service
   
   [Unit]
   Description=Backend Controller For Lndg
@@ -481,8 +481,8 @@ To have updated information in the GUI, it is necessary to regularly run the scr
   User=lndg
   Group=lndg
   ExecStart=/home/lndg/lndg/.venv/bin/python /home/lndg/lndg/controller.py
-  StandardOuput=append:/var/log/controller-lndg.log
-  StandardError=append:/var/log/controller-lndg-error.log
+  StandardOuput=append:/var/log/lndg-controller.log
+  StandardError=append:/var/log/lndg-controller.log
   Restart=always
   RestartSec=60s
 
@@ -493,15 +493,15 @@ To have updated information in the GUI, it is necessary to regularly run the scr
 * Enable the service to start at boot. Start the service and check its status. Exit with `Ctrl`+`c`.
 
   ```sh
-  $ sudo systemctl enable controller-lndg.service
-  $ sudo systemctl start controller-lndg.service
-  $ sudo systemctl status controller-lndg.service
+  $ sudo systemctl enable lndg-controller.service
+  $ sudo systemctl start lndg-controller.service
+  $ sudo systemctl status lndg-controller.service
   ```
 
 * Check that the backend refreshes Python script is run every 20 seconds or so
 
   ```sh
-  $ sudo journalctl -f -u controller-lndg.service
+  $ sudo journalctl -f -u lndg-controller.service
   > [...]
   > Fri Oct 13 14:11:51 2023 : [Data] : Starting data execution...
   > Fri Oct 13 14:12:00 2023 : [Rebalancer] : Queue currently has 0 items...
@@ -617,7 +617,7 @@ With the Tor browser, you can access this onion address from any device.
  
   ```sh
   $ cd /etc/systemd/system/
-  $ sudo rm uwsgi.service controller-lndg.service  
+  $ sudo rm uwsgi.service lndg-controller.service  
   $ cd
   ```
 

--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -586,7 +586,7 @@ With the Tor browser, you can access this onion address from any device.
   $ git fetch
   $ git reset --hard HEAD
   $ git tag
-  $ git checkout v1.8.0
+  $ git checkout tags/v1.8.0
   $ .venv/bin/pip install -r requirements.txt
   $ .venv/bin/pip install --upgrade protobuf
   $ rm lndg/settings.py
@@ -594,8 +594,29 @@ With the Tor browser, you can access this onion address from any device.
   $ .venv/bin/python manage.py migrate
   $ exit
   ```
- 
+
+* On update from 1.7.x to 1.8.0 the following python package may be removed, also remove `qr_code` from the `INSTALLED_APPS` section of `lndg/settings.py` as described [here](https://github.com/cryptosharks131/lndg/releases/tag/v1.8.0):
+
+  ```sh
+  $ .venv/bin/pip uninstall django-qr-code
+  ```
   
+* Also remove unnecessary systemd services:
+
+  ```sh
+  $ sudo systemctl disable jobs-lndg.timer
+  $ sudo systemctl stop jobs-lndg.service
+  $ sudo systemctl disable rebalancer-lndg.timer
+  $ sudo systemctl stop rebalancer-lndg.service
+  $ sudo systemctl stop htlc-stream-lndg.service
+  $ sudo systemctl disable  htlc-stream-lndg.service
+  $ sudo rm /etc/systemd/system/jobs-lndg.timer
+  $ sudo rm /etc/systemd/system/jobs-lndg.service
+  $ sudo rm /etc/systemd/system/rebalancer-lndg.timer
+  $ sudo rm /etc/systemd/system/rebalancer-lndg.service
+  $ sudo rm /etc/systemd/system/htlc-stream-lndg.service
+  ```
+ 
 * Start the `uwsgi` systemd service again. The other LNDg timers and services will start automatically.
 
   ```sh

--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -502,7 +502,7 @@ To have updated information in the GUI, it is necessary to regularly run the scr
 * Check that the backend refreshes Python script is run every 20 seconds or so
 
   ```sh
-  $ sudo journalctl -f -u lndg-controller.service
+  $ tail -f /var/log/lndg-controller.log
   > [...]
   > Fri Oct 13 14:11:51 2023 : [Data] : Starting data execution...
   > Fri Oct 13 14:12:00 2023 : [Rebalancer] : Queue currently has 0 items...
@@ -584,9 +584,9 @@ With the Tor browser, you can access this onion address from any device.
 
   ```sh
   $ cd /home/lndg/lndg
-  $ git fetch
+  $ git fetch --all --tags
   $ git reset --hard HEAD
-  $ git tag
+  $ git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1
   $ git checkout tags/v1.8.0
   $ .venv/bin/pip install -r requirements.txt
   $ .venv/bin/pip install --upgrade protobuf
@@ -596,7 +596,7 @@ With the Tor browser, you can access this onion address from any device.
   $ exit
   ```
 
-* Upgrading from 1.7.x to 1.8.0 the following python package may be removed:
+* Upgrading from 1.7.x to 1.8.0 the following python package may be removed optionally:
 
   ```sh
   $ .venv/bin/pip uninstall django-qr-code
@@ -628,6 +628,12 @@ With the Tor browser, you can access this onion address from any device.
   ```
 
 * Save and exit: Ctrl+O, Ctrl+X
+
+* Return to `admin`:
+
+  ```sh
+  $ exit
+  ```
   
 * Also remove unnecessary systemd services:
 

--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -610,7 +610,9 @@ With the Tor browser, you can access this onion address from any device.
 
   ```sh
   $ sudo systemctl stop uwsgi.service
+  $ sudo systemctl stop lndg-controller.service
   $ sudo systemctl disable uwsgi.service
+  $ sudo systemctl disable lndg-controller.service
   ```
 
 * Delete all the LNDg systemd services and timers

--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -482,7 +482,7 @@ To have updated information in the GUI, it is necessary to regularly run the scr
   User=lndg
   Group=lndg
   ExecStart=/home/lndg/lndg/.venv/bin/python /home/lndg/lndg/controller.py
-  StandardOuput=append:/var/log/lndg-controller.log
+  StandardOutput=append:/var/log/lndg-controller.log
   StandardError=append:/var/log/lndg-controller.log
   Restart=always
   RestartSec=60s

--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -606,7 +606,7 @@ With the Tor browser, you can access this onion address from any device.
 
 ## Uninstall
 
-* Stop and disable the `uwsgi` systemd service
+* Stop and disable the `uwsgi` and `lndg-controller` systemd services
 
   ```sh
   $ sudo systemctl stop uwsgi.service

--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -96,8 +96,9 @@ For that we will create a separate user and we will be running the code as the n
   $ echo $LATEST_RELEASE
   > v1.8.0
 
-  $ git clone --branch $LATEST_RELEASE https://github.com/cryptosharks131/lndg.git
+  $ git clone https://github.com/cryptosharks131/lndg.git
   $ cd lndg
+  $ git checkout tags/$LATEST_RELEASE
   ```
   
 * Setup a Python virtual environment
@@ -586,7 +587,7 @@ With the Tor browser, you can access this onion address from any device.
   $ git fetch
   $ git reset --hard HEAD
   $ git tag
-  $ git checkout v1.8.0
+  $ git checkout tags/v1.8.0
   $ .venv/bin/pip install -r requirements.txt
   $ .venv/bin/pip install --upgrade protobuf
   $ rm lndg/settings.py

--- a/guide/bonus/lightning/lndg.md
+++ b/guide/bonus/lightning/lndg.md
@@ -586,7 +586,7 @@ With the Tor browser, you can access this onion address from any device.
   $ git fetch
   $ git reset --hard HEAD
   $ git tag
-  $ git checkout tags/v1.8.0
+  $ git checkout v1.8.0
   $ .venv/bin/pip install -r requirements.txt
   $ .venv/bin/pip install --upgrade protobuf
   $ rm lndg/settings.py
@@ -595,11 +595,38 @@ With the Tor browser, you can access this onion address from any device.
   $ exit
   ```
 
-* On update from 1.7.x to 1.8.0 the following python package may be removed, also remove `qr_code` from the `INSTALLED_APPS` section of `lndg/settings.py` as described [here](https://github.com/cryptosharks131/lndg/releases/tag/v1.8.0):
+* Upgrading from 1.7.x to 1.8.0 the following python package may be removed:
 
   ```sh
   $ .venv/bin/pip uninstall django-qr-code
   ```
+
+* Also remove `qr_code` from the `INSTALLED_APPS` section of `lndg/settings.py` as described [here](https://github.com/cryptosharks131/lndg/releases/tag/v1.8.0):
+
+  ```sh
+  $ nano /home/lndg/lndg/lndg/settings.py
+  ```
+
+* Result looks like this:
+  
+  ```ini
+  # Application definition
+  
+  INSTALLED_APPS = [
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'django.contrib.admin',
+    'django.contrib.humanize',
+    'gui',
+    'rest_framework',
+    'django_filters',
+  ]
+  ```
+
+* Save and exit: Ctrl+O, Ctrl+X
   
 * Also remove unnecessary systemd services:
 


### PR DESCRIPTION
#### What

This PR updates LNDg to latest version 1.8.0. This requires substinential changes to required systemd services.
By implementing a central controller unit, there's now only one single systemd service required that collects data, runs rebalances and fetches htlc stream data (next to uwsgi).

### Why

Keeping up with latest changes. Simplifying the guide with this update.

#### How

Local test following installation insctructions: https://github.com/cryptosharks131/lndg/releases/tag/v1.8.0
