### PR TITLE
guide/rpi: command for installing nginx stream module

### DIFF
--- a/guide/raspberry-pi/security.md
+++ b/guide/raspberry-pi/security.md
@@ -284,6 +284,13 @@ This setup is called a "reverse proxy": NGINX provides secure communication to t
   > nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
   > nginx: configuration file /etc/nginx/nginx.conf test is successful
   ```
+  
+If you run into the `unknown directive "stream"` error, then you need to install
+the stream module first:
+
+  ```sh
+  $ sudo apt install libnginx-mod-stream
+  ```
 
 ## Disable wireless interfaces
 


### PR DESCRIPTION
#### What

Add the command to install the nginx stream module incase of ``unknown directive "stream"`. 

### Why

I was making my way step-by-step through the guide but ran into the `unknown directive "stream" in /etc/nginx/nginx.conf:10` error when trying to validate the nginx config. It's not immediately clear what the
issue is for peeps unfamiliar with nginx modules. 

#### How

How was this change accomplished?

#### Scope

simple helper incase of nginx config issues. 
