### PR TITLE
[UPDATE] Bitcoin Core bump to coming v25.1

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -23,7 +23,7 @@ We install [Bitcoin Core](https://bitcoin.org/en/bitcoin-core/){:target="_blank"
 ## This may take some time
 
 Bitcoin Core will download the full Bitcoin blockchain, and validate all transactions since 2009.
-We're talking more than 700'000 blocks with a size of over 400 GB, so this is not an easy task.
+We're talking more than 800'000 blocks with a size of over 500 GB, so this is not an easy task.
 It's great that the Raspberry Pi 4 can do it, even if it takes a few days, as this was simply not possible with earlier models.
 
 ---
@@ -45,8 +45,8 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   # set up some version variables for easier maintenance later on
-  $ VERSION="25.0"
-  
+  $ VERSION="25.1"
+
   # download Bitcoin Core binary
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
 
@@ -63,7 +63,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   $ sha256sum --ignore-missing --check SHA256SUMS
-  > bitcoin-25.0-aarch64-linux-gnu.tar.gz: OK
+  > bitcoin-25.1-aarch64-linux-gnu.tar.gz: OK
   ```
 
 ### Signature check
@@ -105,12 +105,12 @@ Expected output:
 ### Timestamp check
 
 * The binary checksum file is timestamped on the Bitcoin blockchain via the [OpenTimestamps protocol](https://opentimestamps.org/){:target="_blank"}, proving that the file existed prior to some point in time. Let's verify this timestamp. On your local computer, download the checksums file and its timestamp proof:
-  *  https://bitcoincore.org/bin/bitcoin-core-25.0/SHA256SUMS.ots
-  *  https://bitcoincore.org/bin/bitcoin-core-25.0/SHA256SUMS
+  *  https://bitcoincore.org/bin/bitcoin-core-25.1/SHA256SUMS.ots
+  *  https://bitcoincore.org/bin/bitcoin-core-25.1/SHA256SUMS
 * In your browser, open the [OpenTimestamps website](https://opentimestamps.org/){:target="_blank"}
 * In the "Stamp and verify" section, drop or upload the downloaded SHA256SUMS.ots proof file in the dotted box
 * In the next box, drop or upload the SHA256SUMS file
-* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v25.0){:target="_blank"} of Bitcoin Core v25.0.
+* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v25.1){:target="_blank"} of Bitcoin Core v25.1.
 
 ![Bitcoin timestamp check](../../images/bitcoin-ots-check.PNG)
 
@@ -122,7 +122,7 @@ Expected output:
   $ tar -xvf bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
   $ sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-$VERSION/bin/*
   $ bitcoind --version
-  > Bitcoin Core version v25.0.0
+  > Bitcoin Core version v25.1.0
   > [...]
   ```
 
@@ -529,7 +529,7 @@ When upgrading, there might be breaking changes, or changes in the data structur
 
   ```sh
   # set up some version variables for easier maintenance later on
-  $ VERSION="25.0"
+  $ VERSION="25.1"
   # download Bitcoin Core binary, checksums, signature file, and timestamp file
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/SHA256SUMS
@@ -541,7 +541,7 @@ When upgrading, there might be breaking changes, or changes in the data structur
 
   ```sh
   $ sha256sum --ignore-missing --check SHA256SUMS
-  > bitcoin-25.0-aarch64-linux-gnu.tar.gz: OK
+  > bitcoin-25.1-aarch64-linux-gnu.tar.gz: OK
   ```
 
 * The next command download and imports automatically all signatures from the [Bitcoin Core release attestations (Guix)](https://github.com/bitcoin-core/guix.sigs) repository
@@ -582,7 +582,7 @@ Expected output:
   $ ots --no-cache verify SHA256SUMS.ots -f SHA256SUMS
   ```
 
-The following output is just an example of one of the versions:
+The following output is just an **example** of one of the versions:
 
   ```sh
   > Got 1 attestation(s) from https://btc.calendar.catallaxy.com
@@ -605,7 +605,7 @@ Now, just check that the timestamp date is close to the [release](https://github
 
   ```sh
   $ bitcoind --version
-  > Bitcoin Core version v25.0.0
+  > Bitcoin Core version v25.1.0
   > Copyright (C) 2009-2023 The Bitcoin Core developers
   > [...]
   ```


### PR DESCRIPTION
#### What

Update the Bitcoin Core guide to the coming latest release 25.1

#### Scope

- [X] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

### Refs

https://bitcoincore.org/bin/bitcoin-core-25.1/
https://github.com/bitcoin-core/bitcoincore.org/blob/b6650ed009635d85c3f3081f74a4057b4beedbfb/_releases/25.1.md


#### Test & maintenance

Tested for me:

![running-bitcoin-core-25 1](https://github.com/raspibolt/raspibolt/assets/89636253/475c2cb8-41db-41d0-89ac-345f23c43fd3)