### PR TITLE
changed node.js installation method using nodesource

### DIFF
--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -44,7 +44,7 @@ curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg 
 
 ```sh
 NODE_MAJOR=20
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+echo "deb [arch=arm64 signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 ```
 
 3. Update apt and install Node.js using the apt package manager

--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -29,16 +29,31 @@ We install [Ride The Lightning](https://github.com/Ride-The-Lightning/RTL#readme
 Starting with user “admin”, we add the Node.js package repository.
 If you installed BTC RPC Explorer, then you've already accomplished this step.
 
-* Add the Node.js (LTS version) software repository
+* Install Node.js (LTS version) using [nodesource distributions](https://github.com/nodesource/distributions/tree/master)
+ 
+1. Download and import the Nodesource GPG key
 
-  ```sh
-  $ curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
-  ```
+```sh
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+```
 
-* Install Node.js using the apt package manager
-  ```
-  $ sudo apt install nodejs
-  ```
+2. Create deb repository
+
+```sh
+NODE_MAJOR=20
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+```
+
+3. Update apt and install Node.js using the apt package manager
+
+```sh
+sudo apt-get update
+sudo apt-get install nodejs -y
+```
+
 
 ### Firewall & reverse proxy
 


### PR DESCRIPTION
#### What

What is the reason of this change?
The old installation method  is deprecated 
  ```sh
  $ curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
  ```
I changed the installation method using [distributions](https://github.com/nodesource/distributions/tree/master)

### Why

Why is this change important?
Running the setup_tls script I got a "Script Deprecation Warning" and a link to distributions repo

#### How

How was this change accomplished?
Trying following the guide
#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix

Fixes # (link issue)

#### Test & maintenance

How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?

Change can be tested by running the deprecated script and following the installation guide. 
By following the updated guide, I was able to correctly install node v20.8.1 on my raspi-pi4