### PR TITLE
[UPDATE BONUS GUIDE] LiT 0.12.0

### DIFF
--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -154,7 +154,7 @@ Because Pool is alpha software, Lightning Terminal is also alpha software.
 
   ```sh
   $ sudo mkdir /data/lit /data/loop /data/pool /data/faraday /data/tapd
-  $ sudo chown -R lit:lit /data/lit /data/loop /data/pool /data/faraday
+  $ sudo chown -R lit:lit /data/lit /data/loop /data/pool /data/faraday /data/tapd
   ```
 
 * Add the "admin" user to the "lit" group


### PR DESCRIPTION
### What

This PR updates Lightning Terminal to version 0.12.0 introducing tapd/tapcli binaries, data dir and aliases and fixing ssl  setup for nginx.

### Why

Keeping bonus guides updated. 

#### How

Following github installation instructions: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.12.0-alpha

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bonus guide update

Replaces #1361
Fixes #1371 
