### PR TITLE
fix c-lightning-REST plugin support for CLN>=23.08

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -495,6 +495,16 @@ c-lightning-Rest: REST APIs for c-lightning written with node.js and provided wi
   UNUSUAL plugin-plugin.js: --- cl-rest api server is ready and listening on port: 3092 ---
   UNUSUAL plugin-plugin.js: --- cl-rest doc server is ready and listening on port: 4091 ---
   ```
+  
+* Starting from v23.08, CLNRest is the [built-in Core Lightning plugin](https://docs.corelightning.org/docs/rest#clnrest) that transforms RPC calls into a REST service, and it is enabled by default. If you are facing issues when starting the `lightningd` service, you need to add the following parameter in the first line of the `# cln-rest-plugin` section, into the `lightningd` config file:
+  ```ini
+  # cln-rest-plugin
+  disable-plugin=/home/lightningd/lightning/plugins/clnrest/clnrest.py # add this line
+  plugin=/data/lightningd-plugins-available/c-lightning-REST-0.10.7/clrest.js
+  rest-port=3092
+  rest-docport=4091
+  rest-protocol=http
+  ```
 
 ### Access over Tor
 


### PR DESCRIPTION
#### What
Add instructions to support c-lightning-REST plugin for CLN version >=23.08

### Why
The lightningd process would not start without disabling the built-in clnrest plugin.
This PR partially addresses #1345 as well.

#### How
Tested on my own lab.

#### Scope
- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance
The guide will eventually migrate to the new plugin when RTL will natively support it (@ShahanaFarooqui is working on it [in this branch](https://github.com/Ride-The-Lightning/RTL/tree/clnrest-migration)).

