### PR TITLE
[UPDATE] Update I2P guide

### DIFF
--- a/guide/bonus/bitcoin/i2p.md
+++ b/guide/bonus/bitcoin/i2p.md
@@ -64,12 +64,6 @@ Table of contents
   $ sudo apt install i2pd
   ```
 
-* Enable autoboot on startup
-
-  ```sh
-  $ sudo systemctl enable i2pd
-  ```
-
 * Check the service is running and the correct autoboot is enabled
 
   ```sh


### PR DESCRIPTION
#### What

Now, the I2P installation automatically enables the autoboot feature

This change is to update the guide to the latest requirements

### Why

Keep the guide updated

#### How

- Deleting unnecessary commands to enable the autoboot feature

#### Scope

- [ ] significant change to core configuration
- [X] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Tested for me using a fresh new installation 

![i2p_delete_autoboot](https://github.com/raspibolt/raspibolt/assets/89636253/f900e012-e73f-427d-b251-355c7c7fcc83)
![i2p_delete_autoboot_2](https://github.com/raspibolt/raspibolt/assets/89636253/ca8b1ac5-8de2-4504-b359-a2e08fe63a11)
