### PR TITLE
[UPDATE] Update Configuration section

### DIFF
--- a/guide/raspberry-pi/system-configuration.md
+++ b/guide/raspberry-pi/system-configuration.md
@@ -69,7 +69,7 @@ The “Advanced Packaging Tool” (apt) makes this easy.
 * Make sure that all necessary software packages are installed:
 
   ```sh
-  $ sudo apt install git --install-recommends
+  $ sudo apt install git
   ```
 
 ---


### PR DESCRIPTION
#### What

`sudo apt install git --install-recommends` and `sudo apt install git` take the same effect

### Why

Keep the guide updated

#### How

- Changing the command to delete unnecessary `--install-recommends` flag

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix

#### Test & maintenance

Tested for me using a fresh new installation

![delete-install_reccomends](https://github.com/raspibolt/raspibolt/assets/89636253/d9102c41-27dd-485b-91a0-1bf8663ab20a)