### PR TITLE
bitcoin: update to release version v26.0

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -45,7 +45,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   # set up some version variables for easier maintenance later on
-  $ VERSION="25.1"
+  $ VERSION="26.0"
 
   # download Bitcoin Core binary
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
@@ -63,7 +63,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   $ sha256sum --ignore-missing --check SHA256SUMS
-  > bitcoin-25.1-aarch64-linux-gnu.tar.gz: OK
+  > bitcoin-26.0-aarch64-linux-gnu.tar.gz: OK
   ```
 
 ### Signature check
@@ -105,12 +105,12 @@ Expected output:
 ### Timestamp check
 
 * The binary checksum file is timestamped on the Bitcoin blockchain via the [OpenTimestamps protocol](https://opentimestamps.org/){:target="_blank"}, proving that the file existed prior to some point in time. Let's verify this timestamp. On your local computer, download the checksums file and its timestamp proof:
-  *  https://bitcoincore.org/bin/bitcoin-core-25.1/SHA256SUMS.ots
-  *  https://bitcoincore.org/bin/bitcoin-core-25.1/SHA256SUMS
+  *  https://bitcoincore.org/bin/bitcoin-core-26.0/SHA256SUMS.ots
+  *  https://bitcoincore.org/bin/bitcoin-core-26.0/SHA256SUMS
 * In your browser, open the [OpenTimestamps website](https://opentimestamps.org/){:target="_blank"}
 * In the "Stamp and verify" section, drop or upload the downloaded SHA256SUMS.ots proof file in the dotted box
 * In the next box, drop or upload the SHA256SUMS file
-* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v25.1){:target="_blank"} of Bitcoin Core v25.1.
+* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v26.0){:target="_blank"} of Bitcoin Core v26.0.
 
 ![Bitcoin timestamp check](../../images/bitcoin-ots-check.PNG)
 
@@ -122,7 +122,7 @@ Expected output:
   $ tar -xvf bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
   $ sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-$VERSION/bin/*
   $ bitcoind --version
-  > Bitcoin Core version v25.1.0
+  > Bitcoin Core version v26.0
   > [...]
   ```
 
@@ -529,7 +529,7 @@ When upgrading, there might be breaking changes, or changes in the data structur
 
   ```sh
   # set up some version variables for easier maintenance later on
-  $ VERSION="25.1"
+  $ VERSION="26.0"
   # download Bitcoin Core binary, checksums, signature file, and timestamp file
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/SHA256SUMS
@@ -541,7 +541,7 @@ When upgrading, there might be breaking changes, or changes in the data structur
 
   ```sh
   $ sha256sum --ignore-missing --check SHA256SUMS
-  > bitcoin-25.1-aarch64-linux-gnu.tar.gz: OK
+  > bitcoin-26.0-aarch64-linux-gnu.tar.gz: OK
   ```
 
 * The next command download and imports automatically all signatures from the [Bitcoin Core release attestations (Guix)](https://github.com/bitcoin-core/guix.sigs) repository
@@ -605,7 +605,7 @@ Now, just check that the timestamp date is close to the [release](https://github
 
   ```sh
   $ bitcoind --version
-  > Bitcoin Core version v25.1.0
+  > Bitcoin Core version v26.0
   > Copyright (C) 2009-2023 The Bitcoin Core developers
   > [...]
   ```

--- a/guide/bonus/bitcoin/i2p.md
+++ b/guide/bonus/bitcoin/i2p.md
@@ -159,12 +159,12 @@ We need to set up settings in Bitcoin Core configuration file to enable I2P conn
 Example output expected, ensure of the presence of "i2p" network:
 
   ```
-  Bitcoin Core client v24.0.1 - server 70016/Satoshi:24.0.1/
-
-            ipv4    ipv6   onion   i2p   total   block
-  in          0       0      25     2      27
-  out         7       0       2     1      10       2
-  total       7       0      27     3      37
+  Bitcoin Core client v26.0 - server 70016/Satoshi:26.0.0/
+  
+           ipv4    ipv6   onion     i2p     npr   total   block  manual
+  in          0       0       0       0       0       0
+  out         0       0       0       0       1       1       0       1
+  total       0       0       0       0       1       1
   ```
 
 💡 If you do not obtain I2P connections in a lot of time, you can add some peers manually by adding these lines at the end of the `bitcoin.conf` file:


### PR DESCRIPTION
Update guide to Bitcoin Core release version v26.0.

NB. The pinned message in Telegram group @ raspibolt still mentions v24.0.1, so could be updated too?