### PR TITLE
[BONUES GUIDE UPDATE] CLN 23.11 + CLNREST plugin

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -79,7 +79,6 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   $ sudo apt-get install -y \
     autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev \
     python3 python3-pip net-tools zlib1g-dev libsodium-dev gettext
-  $ pip3 install --user --upgrade pip
   ```
 
 * Open a "lightningd" user session and create symbolic links to `bitcoin` and `lightningd` data directories.
@@ -104,20 +103,22 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   $ git clone https://github.com/ElementsProject/lightning.git
   $ cd lightning
   $ git fetch --all --tags
-  $ git checkout v23.08.1
+  $ git checkout v23.11
   ``` 
 
 * Don't trust, verify! Check who released the current version and get their signing keys and verify checksums. Verification step should output `Good Signature`.
 
   ```sh
-  $ curl https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/rustyrussell.txt | gpg --import
-  $ git verify-tag v23.08.1
+  $ curl https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/pneuroth.txt | gpg --import
+  $ git verify-tag v23.11
   ```
 
-* Download user specific python packages.
+* Download user specific python packages and plugin requirements.
 
   ```sh
+  $ pip3 install --user --upgrade pip  
   $ pip3 install --user mako
+  $ pip3 install -r plugins/clnrest/requirements.txt
   ```
 
 ### Building CLN
@@ -176,6 +177,8 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   experimental-anchors
   # enable dual fund option
   experimental-dual-fund
+  # clnrest plugin
+  clnrest-port=3001
   ```
 
 ### Shortcuts & Aliases

--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -103,14 +103,14 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   $ git clone https://github.com/ElementsProject/lightning.git
   $ cd lightning
   $ git fetch --all --tags
-  $ git checkout v23.11
+  $ git checkout v23.11.1
   ``` 
 
 * Don't trust, verify! Check who released the current version and get their signing keys and verify checksums. Verification step should output `Good Signature`.
 
   ```sh
-  $ curl https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/pneuroth.txt | gpg --import
-  $ git verify-tag v23.11
+  $ curl https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/cdecker.txt | gpg --import
+  $ git verify-tag v23.11.1
   ```
 
 * Download user specific python packages and plugin requirements.


### PR DESCRIPTION
### What

- Updating CLN to v23.11
- Adding `clnrest` as new interface for tools
- Adding instructions how to create runes
- Adding instructions to connect RTL (#1393) via `clnrest` and runes

As of now only few tools support `clnrest` now. Therefore we keep `c-lightning-Rest` as separate plugin installation (both can be installed and used in parallel). 

### Why

Keeping guide updated and making use of latest developments.

### How

Following instructions of multiple guides and testing locally:
- https://github.com/Ride-The-Lightning/RTL/blob/Release-0.15.0/.github/docs/Core_lightning_setup.md#prep-for-execution
- https://docs.corelightning.org/docs/rest#configuration
- https://docs.corelightning.org/reference/lightning-createrune

### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [ ] simple bug fix
