### PR TITLE
Add Python 3.9 installation into Troubleshooting

### DIFF
--- a/guide/bonus/lightning/lnbits.md
+++ b/guide/bonus/lightning/lnbits.md
@@ -47,6 +47,8 @@ Table of contents
   $ sudo add-apt-repository ppa:deadsnakes/ppa
   $ sudo apt install python3.9 python3.9-distutils
   ```
+
+* If problem installing python3.9 follow Troubleshooting guide [Fix Python 3.9 Installation](../../troubleshooting.html#fix-python-3.9-installation)
   
 ### Firewall & reverse proxy
 

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -474,6 +474,37 @@ $ tail -f /home/bitcoin/.lnd/logs/bitcoin/mainnet/lnd.log
 
 ---
 
+## Fix Python 3.9 installation
+
+Install development packages for Python 3.9
+```
+$ sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev -y
+```
+
+Download Python 3.9 source code, unpack and move to bin
+```
+$ wget https://www.python.org/ftp/python/3.9.18/Python-3.9.18.tar.xz
+$ tar -xf Python-3.9.18.tar.xz
+$ sudo mv Python-3.9.18 /usr/local/share/python3.9
+```
+
+Configure, compile, and install Python 3.9
+```
+$ cd /usr/local/share/python3.9
+$ sudo ./configure --enable-optimizations --enable-shared --with-ensurepip=install
+$ sudo make -j 2
+$ sudo make altinstall
+$ sudo ldconfig /usr/local/share/python3.9
+$ python3.9 --version
+```
+
+You should see this output:
+```
+Python 3.9.18
+```
+
+---
+
 We will extend this troubleshooting guide constantly with findings that have been or will be reported in the issues section.
 
 <br /><br />

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -478,7 +478,7 @@ $ tail -f /home/bitcoin/.lnd/logs/bitcoin/mainnet/lnd.log
 
 Install development packages for Python 3.9
 ```
-$ sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev -y
+$ sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev libsecp256k1-dev -y
 ```
 
 Download Python 3.9 source code, unpack and move to bin


### PR DESCRIPTION
#### What

solve problem if fail install python 3.9

### Why

Because can happen

#### How

Do installation compiling by source code

#### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [ ] simple bug fix

#### Test & maintenance

Just follow steps to install python3.9 if fails by apt-get