### PR TITLE
Increase default mempool to 2 GB

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -257,6 +257,9 @@ We'll also set the proper access permissions.
   maxconnections=40
   maxuploadtarget=5000
 
+  # Set the size of the nodes internal mempool (default is 300)
+  maxmempool=2000
+
   # Initial block download optimizations
   dbcache=2000
   blocksonly=1


### PR DESCRIPTION
Recently we have seen many node operators struggling with transactions that are't broadcasted due to being below the purging limit. If a (force) close transactions fee rate is below the purging limit, the node will drop it immediately and therefore it won't be broadcasted at all. We should increase the default mempool size significantly to mitigate this issue.

I'm open to discuss the ideal default size that we should recommend during the initial setup. The 2 GB I'm proposing is just what I have set on my own node.