### PR TITLE
Bump Bitcoin Core from 26.0 to 26.1

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -45,7 +45,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   # set up some version variables for easier maintenance later on
-  $ VERSION="26.0"
+  $ VERSION="26.1"
 
   # download Bitcoin Core binary
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
@@ -63,7 +63,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   $ sha256sum --ignore-missing --check SHA256SUMS
-  > bitcoin-26.0-aarch64-linux-gnu.tar.gz: OK
+  > bitcoin-26.1-aarch64-linux-gnu.tar.gz: OK
   ```
 
 ### Signature check
@@ -105,12 +105,12 @@ Expected output:
 ### Timestamp check
 
 * The binary checksum file is timestamped on the Bitcoin blockchain via the [OpenTimestamps protocol](https://opentimestamps.org/){:target="_blank"}, proving that the file existed prior to some point in time. Let's verify this timestamp. On your local computer, download the checksums file and its timestamp proof:
-  *  https://bitcoincore.org/bin/bitcoin-core-25.1/SHA256SUMS.ots
-  *  https://bitcoincore.org/bin/bitcoin-core-25.1/SHA256SUMS
+  *  https://bitcoincore.org/bin/bitcoin-core-26.1/SHA256SUMS.ots
+  *  https://bitcoincore.org/bin/bitcoin-core-26.1/SHA256SUMS
 * In your browser, open the [OpenTimestamps website](https://opentimestamps.org/){:target="_blank"}
 * In the "Stamp and verify" section, drop or upload the downloaded SHA256SUMS.ots proof file in the dotted box
 * In the next box, drop or upload the SHA256SUMS file
-* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v25.1){:target="_blank"} of Bitcoin Core v25.1.
+* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v26.1){:target="_blank"} of Bitcoin Core v26.1.
 
 ![Bitcoin timestamp check](../../images/bitcoin-ots-check.PNG)
 
@@ -121,8 +121,9 @@ Expected output:
   ```sh
   $ tar -xvf bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
   $ sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-$VERSION/bin/*
-  $ bitcoind --version
-  > Bitcoin Core version v26.0.0
+  $ bitcoin-cli --version
+  > Bitcoin Core RPC client version v26.1.0
+  > Copyright (C) 2009-2023 The Bitcoin Core developers
   > [...]
   ```
 
@@ -534,7 +535,7 @@ When upgrading, there might be breaking changes, or changes in the data structur
 
   ```sh
   # set up some version variables for easier maintenance later on
-  $ VERSION="26.0"
+  $ VERSION="26.1"
   # download Bitcoin Core binary, checksums, signature file, and timestamp file
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/SHA256SUMS
@@ -546,7 +547,7 @@ When upgrading, there might be breaking changes, or changes in the data structur
 
   ```sh
   $ sha256sum --ignore-missing --check SHA256SUMS
-  > bitcoin-26.0-aarch64-linux-gnu.tar.gz: OK
+  > bitcoin-26.1-aarch64-linux-gnu.tar.gz: OK
   ```
 
 * The next command download and imports automatically all signatures from the [Bitcoin Core release attestations (Guix)](https://github.com/bitcoin-core/guix.sigs) repository
@@ -594,7 +595,7 @@ Expected output:
   > Got 1 attestation(s) from https://finney.calendar.eternitywall.com
   > Got 1 attestation(s) from https://bob.btc.calendar.opentimestamps.org
   > Got 1 attestation(s) from https://alice.btc.calendar.opentimestamps.org
-  > Success! Bitcoin block 819963 attests existence as of 2023-12-06 UTC
+  > Success! Bitcoin block 836722 attests existence as of 2024-03-29 EET
   ```
 
 Now, just check that the timestamp date is close to the [release](https://github.com/bitcoin/bitcoin/releases) date of the version you're installing.
@@ -610,7 +611,7 @@ Now, just check that the timestamp date is close to the [release](https://github
 
   ```sh
   $ bitcoin-cli --version
-  > Bitcoin Core RPC client version v26.0.0
+  > Bitcoin Core RPC client version v26.1.0
   > Copyright (C) 2009-2023 The Bitcoin Core developers
   > [...]
   ```


### PR DESCRIPTION
#### What

Update the Bitcoin Core guide to the latest release 26.1.

### Why

Keeping up with latest developments and improvements (see [release notes](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-26.1.md)).

#### Scope

- [X] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix