### PR TITLE
CLN: Remove deprecated configs

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -159,9 +159,6 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   large-channels
   # channel confirmations needed
   funding-confirms=2
-  # autoclean (86400=daily)
-  autocleaninvoice-cycle=86400
-  autocleaninvoice-expired-by=86400
   # wallet settings (replication recommended, adjust backup path)
   wallet=sqlite3:///data/lightningd/bitcoin/lightningd.sqlite3:/home/lightningd/lightningd.sqlite3
   # no replication:


### PR DESCRIPTION
#### What

CLN configs `autocleaninvoice-cycle` and `autocleaninvoice-expired-by` were deprecated with v22.11 and EOL v24.02. https://github.com/ElementsProject/lightning/pull/7094

### Why

I had random startup failures on different Ubuntu Server machine running v24.02.2 (not a RaspiBolt, it's x86_64, but that shouldn't change things much here.

#### Scope

- [ ] significant change to core configuration
- [X] independent bonus guide
- [ ] simple bug fix