### PR TITLE
[UPDATE BONUS GUIDE] Update python dependencies to install CLN

### DIFF
--- a/guide/bonus/lightning/cln.md
+++ b/guide/bonus/lightning/cln.md
@@ -114,10 +114,12 @@ We will download, verify, install and configure CLN on your RaspiBolt setup. Thi
   $ git verify-tag v23.08.1
   ```
 
-* Download user specific python packages.
+* Still as user "lightningd" download user specific python packages.
 
   ```sh
-  $ pip3 install --user mako
+  $ pip3 install --user --upgrade pip
+  $ pip3 install --user mako grpcio-tools
+  $ pip3 install --user -r plugins/clnrest/requirements.txt
   ```
 
 ### Building CLN


### PR DESCRIPTION
#### What

Stay up to date to version 24 without crashing the installation

### Why

Because useres are complaining that using our guide they cannot install version 24:
https://bitcointalk.org/index.php?topic=5492706.0

#### How

Followed the official installation of CLN
https://github.com/ElementsProject/lightning/blob/master/doc/getting-started/getting-started/installation.md

#### Scope

- [ ] significant change to core configuration
- [X] independent bonus guide
- [ ] simple bug fix


