### PR TITLE
Update bitcoin core version variale. Change master to main in the cha…

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -45,7 +45,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   # set up some version variables for easier maintenance later on
-  $ VERSION="26.1"
+  $ VERSION="27.0"
 
   # download Bitcoin Core binary
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION-aarch64-linux-gnu.tar.gz

--- a/guide/lightning/channel-backup.md
+++ b/guide/lightning/channel-backup.md
@@ -152,7 +152,7 @@ We create a shell script to monitor `channel.backup` and make a copy to our back
     git add .
     git commit -m "Static Channel Backup $(date +"%Y%m%d-%H%M%S")"
     echo "Pushing changes to remote repository..."
-    git push --set-upstream origin master
+    git push --set-upstream origin main
     echo "Success! The file is now remotely backed up!"
   }
 
@@ -370,7 +370,7 @@ Follow this section if you want a remote backup. If you already set up a local b
   $ touch test
   $ git add .
   $ git commit -m "testing"
-  $ git push --set-upstream origin master
+  $ git push --set-upstream origin main
   ```
 
 * Check that a copy of the test file is now in your remote GitHub repository (in the `[ <> Code ]` tab).


### PR DESCRIPTION
#### What

I recently used this guide with the latest version of Bitcoin Core (v0.27.0), and everything worked perfectly. I also made a small change in the channel backup section, replacing "master" with "main".

### Why

I don't think updating to the latest Bitcoin core is very important. However, I do believe that replacing "master" with "main" is. Since last year, the default branches on GitHub repositories are named "main" instead of "master". This was one of the few things I had to change while following the guide.

#### How

Adapting `channel-backup.md` and `bitcoin-client.md` file

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes # (link issue)

#### Test & maintenance

> How can the changes be tested? 

Upgrade Bitcoin Core

> Is there ongoing maintenance effort?

No

> If this is a bonus guide: are you willing to update it from time to time?

N/A

