### PR TITLE
Update lightning-client.md

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -207,7 +207,7 @@ To improve the security of your wallet, check out these more advanced methods:
   # Channel settings
   bitcoin.basefee=1000
   bitcoin.feerate=1
-  minchansize=100000
+  minchansize=25000
   accept-keysend=true
   accept-amp=true
   protocol.wumbo-channels=true


### PR DESCRIPTION
Decrease lnd.conf minchansize from 100000 to 25000 to represent the user sending "a small amount of bitcoin" as the guide suggests.

#### What

Increased BTC price means that the suggested minimum channel size of 100,000 satoshis is not necessarily considered "a small amount" anymore. Cited from the guide:

> One Bitcoin equals 100 million satoshis, so at $10’000/BTC, $10 amount to 0.001 BTC or 100’000 satoshis.

At the time of writing, 100,000 satoshis is now worth around $60 USD. I propose that the minchansize is reduced to 25,000 which is still more than enough to close a channel if needed, and accounts for around $15 USD worth of liquidity.
### Why

With the default config suggested by the guide, LND will reject opening channels that are under 100,000 satsoshis, which seems unreasonable and may trip people up. This change makes more sense for new users who are likely to deposit <20 USD. 

#### How

Changed minchansize value in lnd.conf in lightning-client.md from 100000 to 25000. 


#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix

Fixes # (link issue)

#### Test & maintenance
I have used LND with this config as part of the RaspiBolt guide with no issues. It should not conflict with any other part of the guide.

#### Animated GIF (optional)

Add some snazz if you feel like it :)
