### PR TITLE
Change usage of .bitcoin, .lnd, and .loop links

### DIFF
--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -153,7 +153,7 @@ We get the latest release of the Electrs source code, verify it, compile it to a
 
   # Bitcoin Core settings
   network = "bitcoin"
-  daemon_dir= "/home/bitcoin/.bitcoin"
+  daemon_dir= "/data/bitcoin"
   daemon_rpc_addr = "127.0.0.1:8332"
   daemon_p2p_addr = "127.0.0.1:8333"
 
@@ -174,7 +174,7 @@ We get the latest release of the Electrs source code, verify it, compile it to a
   ```
 
   ```sh
-  Starting electrs 0.9.14 on aarch64 linux with Config { network: Bitcoin, db_path: "/data/electrs/db/bitcoin", daemon_dir: "/home/bitcoin/.bitcoin", daemon_auth: CookieFile("/home/bitcoin/.bitcoin/.cookie"), daemon_rpc_addr: 127.0.0.1:8332, daemon_p2p_addr: 127.0.0.1:8333, electrum_rpc_addr: 127.0.0.1:50001, monitoring_addr: 127.0.0.1:4224, wait_duration: 10s, jsonrpc_timeout: 15s, index_batch_size: 10, index_lookup_limit: Some(1000), reindex_last_blocks: 0, auto_reindex: true, ignore_mempool: false, sync_once: false, disable_electrum_rpc: false, server_banner: "Welcome to electrs 0.9.14 (Electrum Rust Server)!", args: [] }
+  Starting electrs 0.9.14 on aarch64 linux with Config { network: Bitcoin, db_path: "/data/electrs/db/bitcoin", daemon_dir: "/data/bitcoin", daemon_auth: CookieFile("/data/bitcoin/.cookie"), daemon_rpc_addr: 127.0.0.1:8332, daemon_p2p_addr: 127.0.0.1:8333, electrum_rpc_addr: 127.0.0.1:50001, monitoring_addr: 127.0.0.1:4224, wait_duration: 10s, jsonrpc_timeout: 15s, index_batch_size: 10, index_lookup_limit: Some(1000), reindex_last_blocks: 0, auto_reindex: true, ignore_mempool: false, sync_once: false, disable_electrum_rpc: false, server_banner: "Welcome to electrs 0.9.14 (Electrum Rust Server)!", args: [] }
   [2021-11-09T07:09:42.744Z INFO  electrs::metrics::metrics_impl] serving Prometheus metrics on 127.0.0.1:4224
   [2021-11-09T07:09:42.744Z INFO  electrs::server] serving Electrum RPC on 127.0.0.1:50001
   [2021-11-09T07:09:42.812Z INFO  electrs::db] "/data/electrs/db/bitcoin": 0 SST files, 0 GB, 0 Grows

--- a/guide/bonus/bitcoin/dojo.md
+++ b/guide/bonus/bitcoin/dojo.md
@@ -95,7 +95,7 @@ If you are using Electrs instead of Fulcrum, it is necessary to make following c
 * Open `bitcoin.conf`
 
   ```sh
-  $ sudo nano /home/bitcoin/.bitcoin/bitcoin.conf
+  $ sudo nano /data/bitcoin/bitcoin.conf
   ```
 
 * Add following line preferably under "#zmq" or at the end of the file 

--- a/guide/bonus/bitcoin/fulcrum.md
+++ b/guide/bonus/bitcoin/fulcrum.md
@@ -294,7 +294,7 @@ RaspiBolt uses SSL as default for Fulcrum, but some wallets like [BlueWallet](ht
 
   # Bitcoin Core settings
   bitcoind = 127.0.0.1:8332
-  rpccookie = /home/bitcoin/.bitcoin/.cookie
+  rpccookie = /data/bitcoin/.cookie
 
   # Fulcrum server settings
   datadir = /data/fulcrum/fulcrum_db

--- a/guide/bonus/bitcoin/specter-desktop.md
+++ b/guide/bonus/bitcoin/specter-desktop.md
@@ -39,7 +39,7 @@ The default setup guides you on how to allow for plugging in your hardware devic
 
   Open the `bitcoin.conf` file
   ```sh
-  $ sudo nano /home/bitcoin/.bitcoin/bitcoin.conf
+  $ sudo nano /data/bitcoin/bitcoin.conf
   ```
 
   Edit the following values, or add to the end of the file if not set

--- a/guide/bonus/bitcoin/testnet.md
+++ b/guide/bonus/bitcoin/testnet.md
@@ -102,7 +102,7 @@ File location: `/data/electrs/electrs.conf`
 
 # Bitcoin Core settings
 network = "testnet"
-daemon_dir= "/home/bitcoin/.bitcoin/"
+daemon_dir= "/data/bitcoin/"
 daemon_rpc_addr = "127.0.0.1:18332"
 daemon_p2p_addr = "127.0.0.1:18333"
 cookie_file = "/data/bitcoin/testnet3/.cookie"

--- a/guide/bonus/lightning/lightning-terminal.md
+++ b/guide/bonus/lightning/lightning-terminal.md
@@ -531,7 +531,7 @@ If you have installed [Ride The Lightning](../../web-app.md), you can use the Lo
 * Click on the "Services" tab
 * If it's disabled, click on "Enable Loop service"
 * In "Loop Server URL", replace `https://localhost:8081` by `https://localhost:8443`
-* In "Loop Macaroon Path", the path should be `/home/lit/.loop/mainnet`
+* In "Loop Macaroon Path", the path should be `/data/loop/mainnet`
 * Then click the "Update" button
 * Go back to the navigation menu and click on "Services", then "Loop"
 * You can now perform loop ins and loop outs directly from RTL

--- a/guide/bonus/lightning/remote-lncli.md
+++ b/guide/bonus/lightning/remote-lncli.md
@@ -43,7 +43,7 @@ root@RaspiBolt:/home/admin#  ufw status
 root@RaspiBolt:/home/admin#  exit
 ```
 - Add one new line in the [Application Options] section of lnd.conf to allow rpc from more than just the default localhost
-  `admin ~  ฿  sudo nano /home/bitcoin/.lnd/lnd.conf`
+  `admin ~  ฿  sudo nano /data/lnd/lnd.conf`
 
 ```ini
 [Application Options]
@@ -51,7 +51,7 @@ rpclisten=0.0.0.0:10009
 ```
 
 - Temporarily allow admin.macaroon to be copied
-  `admin ~  ฿ sudo chmod 777 /home/bitcoin/.lnd/admin.macaroon`
+  `admin ~  ฿ sudo chmod 777 /data/lnd/admin.macaroon`
 
 ## Windows PC
 
@@ -89,14 +89,14 @@ GLOBAL OPTIONS:
   `> mkdir %LOCALAPPDATA%\Lnd`
 * Use WinSCP to copy the files shown
   * Local:  `\Users\xxxx\AppData\Local\Lnd`
-  * Remote: `/home/bitcoin/.lnd/`
+  * Remote: `/data/lnd/`
   * Files: `See below`
 
  ![Files to Copy](../../../images/60_winLND.png)
 
 
  - Back on the RaspiBolt: Reset admin.macaroon permissions
-   `admin ~  ฿ sudo chmod 600 /home/bitcoin/.lnd/admin.macaroon`
+   `admin ~  ฿ sudo chmod 600 /data/lnd/admin.macaroon`
 
 
 - Run lncli on the PC


### PR DESCRIPTION
#### What

Change usage of "/home/bitcoin/.bitcoin" to "/data/bitcoin" for users other than _bitcoin_.
Change usage of "/home/lnd/.lnd" to "/data/lnd" for users other than _lnd_.
Change usage of "/home/lit/.loop" to "/data/loop" for users other than _lit_.

### Why

Links to `/data/bitcoin` and `/data/lnd` owned by a user should only be used by that user. Also, note that while home directories are `rwxr-xr-x` by default on Raspian, they are `rwx------` on Debian, making these changes necessary for Debian.

#### How

Replaced `/home/bitcoin/.bitcoin` with `/data/bitcoin` and `/home/lnd/.lnd` with `/data/lnd` where referenced by users other than _bitcoin_ and _lnd_.

#### Scope

- [x] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

Fixes #1443

#### Test & maintenance

No maintenance is necessary while bitcoind and lnd remain installed in `/data`.
