### PR TITLE
Bump LND from 0.17.5 to 0.18.4

### DIFF
--- a/guide/lightning/lightning-client.md
+++ b/guide/lightning/lightning-client.md
@@ -32,7 +32,7 @@ We'll download, verify and install LND.
 
   ```sh
   $ cd /tmp
-  $ VERSION="0.17.5"
+  $ VERSION="0.18.4"
   $ wget https://github.com/lightningnetwork/lnd/releases/download/v$VERSION-beta/lnd-linux-arm64-v$VERSION-beta.tar.gz
   $ wget https://github.com/lightningnetwork/lnd/releases/download/v$VERSION-beta/manifest-v$VERSION-beta.txt
   $ wget https://github.com/lightningnetwork/lnd/releases/download/v$VERSION-beta/manifest-roasbeef-v$VERSION-beta.sig
@@ -45,7 +45,7 @@ We'll download, verify and install LND.
 
   ```sh
   $ sha256sum --check manifest-v$VERSION-beta.txt --ignore-missing
-  > lnd-linux-arm64-v0.17.5-beta.tar.gz: OK
+  > lnd-linux-arm64-v0.18.4-beta.tar.gz: OK
   ```
 
 ### Signature check
@@ -65,13 +65,13 @@ Now that we've verified the integrity of the downloaded binary, we need to check
 
   ```sh
   $ gpg --verify manifest-roasbeef-v$VERSION-beta.sig manifest-v$VERSION-beta.txt
-  > gpg: Signature made Tue Apr 23 02:43:45 2024 EEST
-  > gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
+  > gpg: Signature made Wed Dec 18 21:56:51 2024 EET
+  > gpg:                using EDDSA key 296212681AADF05656A2CDEE90525F7DEEE0AD86
   > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [unknown]
   > gpg: WARNING: This key is not certified with a trusted signature!
   > gpg:          There is no indication that the signature belongs to the owner.
-  > Primary key fingerprint: E4D8 5299 674B 2D31 FAA1  892E 372C BD76 33C6 1696
-  >      Subkey fingerprint: 60A1 FA7D A5BF F08B DCBB  E790 3BBD 59E9 9B28 0306
+  > Primary key fingerprint: A5B6 1896 952D 9FDA 83BC  054C DC42 612E 8923 7182
+  >      Subkey fingerprint: 2962 1268 1AAD F056 56A2  CDEE 9052 5F7D EEE0 AD86
   ```
 
 ### Timestamp check
@@ -83,7 +83,7 @@ We can also check that the manifest file was in existence around the time of the
   ```sh
   $ ots --no-cache verify manifest-roasbeef-v$VERSION-beta.sig.ots -f manifest-roasbeef-v$VERSION-beta.sig
   > [...]
-  > Success! Bitcoin block 840472 attests existence as of 2024-04-23 EEST
+  > Success! Bitcoin block 875352 attests existence as of 2024-12-19 EET
   ```
 
 * Check that the date of the timestamp is close to the [release date](https://github.com/lightningnetwork/lnd/releases){:target="_blank"} of the LND binary.
@@ -98,7 +98,7 @@ Having verified the integrity and authenticity of the release binary, we can saf
   $ tar -xvf lnd-linux-arm64-v$VERSION-beta.tar.gz
   $ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-arm64-v$VERSION-beta/*
   $ lnd --version
-  > lnd version 0.17.5-beta commit=v0.17.5-beta
+  > lnd version 0.18.4-beta commit=v0.18.4-beta
   ```
 
 ### Data directory


### PR DESCRIPTION
#### What

Updates LND guide to 0.18.4.

### Why

Keeping up with latest developments and improvements.

Release notes:

* [0.18.0](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.0.md)
* [0.18.1](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.1.md)
* [0.18.2](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.2.md)
* [0.18.3](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.3.md)
* [0.18.4](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.18.4.md)

#### Scope

- [X] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix