### PR TITLE
Bump RTL from 0.15.0 to 0.15.4

### DIFF
--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -315,7 +315,7 @@ Make sure to read the release notes first.
   $ latest=$(git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1); echo $latest
   $ git checkout $latest
   $ git verify-tag $latest
-  $ npm install --omit=dev
+  $ npm install --omit=dev --legacy-peer-deps
   $ exit
   ```
 

--- a/guide/lightning/web-app.md
+++ b/guide/lightning/web-app.md
@@ -116,12 +116,12 @@ We do not want to run Ride the Lightning alongside bitcoind and lnd because of s
   $ cd RTL
 
   $ git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1
-  > v0.15.0
+  > v0.15.4
 
-  $ git checkout v0.15.0
+  $ git checkout v0.15.4
 
-  $ git verify-tag v0.15.0
-  > gpg: Signature made Thu 07 Dec 2023 05:40:57 AM CET
+  $ git verify-tag v0.15.4
+  > gpg: Signature made Tue 19 nov 05:31:13 2024 CET
   > gpg:                using RSA key 3E9BD4436C288039CA827A9200C9E2BC2E45666F
   > gpg: Good signature from "saubyk (added uid) <39208279+saubyk@users.noreply.github.com>" [unknown]
   > gpg:                 aka "Suheb <39208279+saubyk@users.noreply.github.com>" [unknown]


### PR DESCRIPTION
#### What

What is the reason of this change?

Update the RTL guide to reference the latest version of RTL (v0.15.4)

### Why

Why is this change important?

Update to latest version and minimize confusion for beginners as the guide references 0.15.0 but they will see v0.15.4 on their pi when running the command ``git tag | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | sort --version-sort | tail -n 1``

Release Notes:

- [0.15.1](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.15.1)
- [0.15.2](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.15.2)
- [0.15.3](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.15.3)
- [0.15.4](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.15.4)

#### Scope

- [x] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix
