### PR TITLE
Update bitcoin-client.md

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -413,11 +413,13 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   >
   ```
 
-* Check if the permission cookie can be accessed by the group "bitcoin".
+* Check if the permission cookie can be accessed by the group "bitcoin". 
   The output must contain the `-rw-r-----` part, otherwise no application run by a different user can access Bitcoin Core.
 
+This can be either done by the user "admin" or the user "bitcoin" since both user homes are linked to /data/bitcoin/.bitcoin. The tilde (~) is a Linux "shortcut" to denote a user's home directory.
+
   ```sh
-  $ ls -la /home/bitcoin/.bitcoin/.cookie
+  $ ls -la ~/.bitcoin/.cookie
   > -rw-r----- 1 bitcoin bitcoin 75 Dec 17 13:48 /home/bitcoin/.bitcoin/.cookie
   ```
 
@@ -425,7 +427,7 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   Exit with `Ctrl-C`
 
   ```sh
-  $ tail -f /home/bitcoin/.bitcoin/debug.log
+  $ tail -f ~/.bitcoin/debug.log
   ```
 
 * Use the Bitcoin Core client `bitcoin-cli` to get information about the current blockchain

--- a/guide/bitcoin/blockchain-explorer.md
+++ b/guide/bitcoin/blockchain-explorer.md
@@ -56,16 +56,21 @@ You can follow the progress using `tail -f ~/.bitcoin/debug.log`.
 ### Install Node.js
 
 * Add the [Node.js](https://nodejs.org){:target="_blank"} package repository from user "admin".
-  We'll use version 16, which is the latest stable version.
+  We'll use the latest LTS version (22.13 at writing) and we will use the nvm install.
 
   ```sh
-  $ curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
-  ```
+# Download and install nvm:
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
-* Install Node.js using the apt package manager.
+# Download and install Node.js:
+nvm install 22
 
-  ```sh
-  $ sudo apt install nodejs
+# Verify the Node.js version:
+node -v # Should print "v22.13.0".
+nvm current # Should print "v22.13.0".
+
+# Verify npm version:
+npm -v # Should print "10.9.2".
   ```
 
 ### Firewall & reverse proxy

--- a/guide/bitcoin/blockchain-explorer.md
+++ b/guide/bitcoin/blockchain-explorer.md
@@ -59,18 +59,18 @@ You can follow the progress using `tail -f ~/.bitcoin/debug.log`.
   We'll use the latest LTS version (22.13 at writing) and we will use the nvm install.
 
   ```sh
-# Download and install nvm:
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-
-# Download and install Node.js:
-nvm install 22
-
-# Verify the Node.js version:
-node -v # Should print "v22.13.0".
-nvm current # Should print "v22.13.0".
-
-# Verify npm version:
-npm -v # Should print "10.9.2".
+  # Download and install nvm:
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+  
+  # Download and install Node.js:
+  nvm install 22
+  
+  # Verify the Node.js version:
+  node -v # Should print "v22.13.0".
+  nvm current # Should print "v22.13.0".
+  
+  # Verify npm version:
+  npm -v # Should print "10.9.2".
   ```
 
 ### Firewall & reverse proxy


### PR DESCRIPTION
Clean up confusion about checking the permission of the /.bitcoin/.cookie and also the viewing of the /.bitcoin/debug.log

#### What
This will clear up some confusion when checking the permissions of /.bitcoin/.cookie and viewing  /.bitcoin/debug.log using both admin and bitcoin user

### Why

Make it less confusing to the inexperienced user to notice that admin can not access /home/bitcoin but can access its own home!

#### How
I simply replaced /home/bitcoin with ~/ and added some comments about ~ sign for beginners.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes # (link issue)
https://github.com/raspibolt/raspibolt/issues/1468

#### Test & maintenance

Tested on local machine with user admin and bitcoin  /home/bitcoin does not work with admin ~/ works with both admin and bitcoin user

