### PR TITLE
🛠️ Update Bonus Guide Bisq: prune & alt start cmds

### DIFF
--- a/guide/bonus/bitcoin/bisq.md
+++ b/guide/bonus/bitcoin/bisq.md
@@ -83,6 +83,7 @@ For Bisq to connect to your Bitcoin Core node, the bloom filters have to be acti
   ```sh
   # Filters
   peerbloomfilters=1   # for Bisq
+  prune=0              # for Bisq (disable pruning old blocks)
   ```
 
 * Add the following line under `"whitelist=download@127.0.0.1       # for Electrs"` line to whitelist our own P2P connection.
@@ -146,10 +147,28 @@ From remote connection, replace `123...abc.onion:8333` with your own Bitcoin Cor
   $ Bisq -btcNodes=192.168.X.X:8333 -useTorForBtc=false
   ```
 
+* Use the full application path if Bisq isn't part of your system's PATH. First find where Bisq is installed (example with drag and drop install):
+
+  ```sh
+  $ ls /Applications | grep -i bisq
+  ```
+
+* Then use that path (example):
+
+  ```sh
+  $ /Applications/Bisq.app/Contents/MacOS/Bisq -btcNodes=192.168.X.X:8333 -useTorForBtc=false
+  ```
+
 * From remote connection, replace `123...abc.onion:8333` with your own Bitcoin Core .onion address that you obtained above.
   
   ```sh
   $ Bisq -btcNodes=123...abc.onion:8333 -useTorForBtc=true
+  ```
+
+* Using full application path if Bisq isn't part of your system's PATH (example from previous section on local network connection):
+
+  ```sh
+  $ /Applications/Bisq.app/Contents/MacOS/Bisq -btcNodes=123...abc.onion:8333 -useTorForBtc=true
   ```
 
 * Wait a few minutes until Bisq is up to date with the current state of the blockchain and go back to "Settings" > "Network info" to check that only your own node local IP address or onion address is listed in the first table.


### PR DESCRIPTION
#### What

The Bisq connection guide for connecting to your own node specifies that you must connect using certain configuration, including an option to not prune old blocks `prune=0` in `bitcoin.conf`. https://bisq.wiki/Connecting_to_your_own_Bitcoin_node#Troubleshooting

Without this setting, Bisq has difficulty maintaining connection to a hidden service (onion address) for a node using a custom connection and may fail to connect to your node. 

This also adds helpful context to the start commands for Bisq via the CLI, whereby a user who does not have `Bisq` as part of their system's `PATH` could be confused as to how to properly start the application using the given command. Adds additional commands, using the full application path in one scenario (most common) for a user who installed Bisq using the "drag and drop" method on MacOS.

### Why

Allows the connection of a self-hosted node to Bisq via the Tor network .
Allows less experienced users to find alternatives to the given commands to start Bisq via the CLI as instructed. 

#### How

Adding additional context to two sections of the md file, one being the section on the `bitcoin.conf` and one on the section relating to starting Bisq via the CLI.

#### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [ ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

Testing is done via starting Bisq and connecting successfully. Unfortunately I did not write a test for this, but rather referenced the documentation and my own experience, for the respective changes described in the `What` section.

I am available to maintain this change and am seeking to make more updates based on my experience implementing this guide successfully. 

#### Animated GIF (optional)

![BTC To the Moon!](https://media0.giphy.com/media/v1.Y2lkPTc9MGI3NjExMmt2ZTBjYXNpejI5Nmt6OHB2d3VjazhzMjd3ZnJnajF2cmM3MnBiZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/7FBY7h5Psqd20/giphy.gif)
