### PR TITLE
Fix OTS install command

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -500,7 +500,7 @@ Now that Bitcoin Core is running and synced, we can install the [OpenTimestamp c
 
   ```sh
   $ sudo apt-get install python3 python3-dev python3-pip python3-setuptools python3-wheel
-  $ sudo pip3 install opentimestamps-client
+  $ sudo pip3 install opentimestamps-client --break-system-packages
   ```
 
 * Display the OpenTimestamps client version to check that it is properly installed


### PR DESCRIPTION
### What

We fix the opentimestamps-client installation command due to python changes: "externally managed". Instead of using `venv`, we install opentimestamps-client system-wide. This requires the option `--break-system-packages`. 

#### How

Extending installation command in `bitcoin-client.md`

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes #1470