### PR TITLE
Update path to firmware configuration file

### DIFF
--- a/guide/raspberry-pi/security.md
+++ b/guide/raspberry-pi/security.md
@@ -300,7 +300,7 @@ That's great for most projects, but we should turn off all radios that are not n
 * Open the RasPi OS configuration file, go to the following comment and add the applicable options below
 
   ```sh
-  $ sudo nano /boot/config.txt
+  $ sudo nano /boot/firmware/config.txt
   ```
 
   ```sh


### PR DESCRIPTION
#### What

Update path to `/boot/firmware/config.txt`.

### Why

It seems to have changed from `/boot/config.txt` to the new one. In my Raspberry Pi I get:
```
$ sudo nano /boot/config.txt

DO NOT EDIT THIS FILE

The file you are looking for has moved to /boot/firmware/config.txt
```
I have
```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 12 (bookworm)
Release:	12
Codename:	bookworm
```
in my Raspberry Pi 4.