### PR TITLE
electrs: fix install & update to 0.10.10

### DIFF
--- a/guide/bitcoin/electrum-server.md
+++ b/guide/bitcoin/electrum-server.md
@@ -43,7 +43,22 @@ Make sure that you have [reduced the database cache of Bitcoin Core](bitcoin-cli
 * Install build tools needed to compile Electrs from the source code
 
   ```sh
-  $ sudo apt install cargo clang cmake
+  $ sudo apt install clang cmake
+  ```
+
+* Install latest cargo release
+  ```sh
+  $ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  ```
+
+* Reload $PATH variable
+  ```sh
+  $ . "$HOME/.cargo/env"
+  ```
+
+* Verify cargo version
+  ```sh
+  $ cargo --version
   ```
 
 ### Firewall & reverse proxy
@@ -98,7 +113,7 @@ We get the latest release of the Electrs source code, verify it, compile it to a
   Other releases might not have been properly tested with the rest of the RaspiBolt configuration, though.
 
   ```sh
-  $ VERSION="0.9.14"
+  $ VERSION="0.10.10"
   $ mkdir /home/admin/rust
   $ cd /home/admin/rust
   $ git clone --branch v$VERSION https://github.com/romanz/electrs.git
@@ -152,6 +167,7 @@ We get the latest release of the Electrs source code, verify it, compile it to a
   # /data/electrs/electrs.conf
 
   # Bitcoin Core settings
+  cookie_file = "/data/bitcoin/.cookie"
   network = "bitcoin"
   daemon_dir= "/data/bitcoin"
   daemon_rpc_addr = "127.0.0.1:8332"
@@ -163,7 +179,6 @@ We get the latest release of the Electrs source code, verify it, compile it to a
 
   # Logging
   log_filters = "INFO"
-  timestamp = true
   ```
 
 * Let's start Electrs manually first to check if everything runs as expected.
@@ -174,7 +189,7 @@ We get the latest release of the Electrs source code, verify it, compile it to a
   ```
 
   ```sh
-  Starting electrs 0.9.14 on aarch64 linux with Config { network: Bitcoin, db_path: "/data/electrs/db/bitcoin", daemon_dir: "/data/bitcoin", daemon_auth: CookieFile("/data/bitcoin/.cookie"), daemon_rpc_addr: 127.0.0.1:8332, daemon_p2p_addr: 127.0.0.1:8333, electrum_rpc_addr: 127.0.0.1:50001, monitoring_addr: 127.0.0.1:4224, wait_duration: 10s, jsonrpc_timeout: 15s, index_batch_size: 10, index_lookup_limit: Some(1000), reindex_last_blocks: 0, auto_reindex: true, ignore_mempool: false, sync_once: false, disable_electrum_rpc: false, server_banner: "Welcome to electrs 0.9.14 (Electrum Rust Server)!", args: [] }
+  Starting electrs 0.10.10 on aarch64 linux with Config { network: Bitcoin, db_path: "/data/electrs/db/bitcoin", daemon_dir: "/data/bitcoin", daemon_auth: CookieFile("/data/bitcoin/.cookie"), daemon_rpc_addr: 127.0.0.1:8332, daemon_p2p_addr: 127.0.0.1:8333, electrum_rpc_addr: 127.0.0.1:50001, monitoring_addr: 127.0.0.1:4224, wait_duration: 10s, jsonrpc_timeout: 15s, index_batch_size: 10, index_lookup_limit: Some(1000), reindex_last_blocks: 0, auto_reindex: true, ignore_mempool: false, sync_once: false, disable_electrum_rpc: false, server_banner: "Welcome to electrs 0.10.10 (Electrum Rust Server)!", args: [] }
   [2021-11-09T07:09:42.744Z INFO  electrs::metrics::metrics_impl] serving Prometheus metrics on 127.0.0.1:4224
   [2021-11-09T07:09:42.744Z INFO  electrs::server] serving Electrum RPC on 127.0.0.1:50001
   [2021-11-09T07:09:42.812Z INFO  electrs::db] "/data/electrs/db/bitcoin": 0 SST files, 0 GB, 0 Grows
@@ -328,14 +343,14 @@ Make sure to check the [release notes](https://github.com/romanz/electrs/blob/ma
   ```sh
   $ cd /home/admin/rust/electrs
 
-  # Clean and update the local source code and show the latest release tag (example: v0.9.14)
+  # Clean and update the local source code and show the latest release tag (example: v0.10.10)
   $ git clean -xfd
   $ git fetch
   $ git tag | sort --version-sort | tail -n 1
-  > v0.9.14
+  > v0.10.10
   
   # Set the VERSION variable as number from latest release tag and verify developer signature
-  $ VERSION="0.9.14"
+  $ VERSION="0.10.10"
   $ git verify-tag v$VERSION
   > gpg: Good signature from "Roman Zeyde <me@romanzey.de>" [unknown]
   > [...]


### PR DESCRIPTION
### What

This PR tries to fix electrs install according to this tested method (https://github.com/raspibolt/raspibolt/issues/1415#issuecomment-2158967661) and upgrades electrs to latest version 0.10.10

- possible fix for deb 11 (also tested on deb 13)
- update to 0.10.10
- removes deprecated timestamp setting 
 
Fixes #1491

cc @managai for review

### Scope

- [x] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix
