### PR TITLE
bitcoin-client: update to 30.0

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -23,7 +23,7 @@ We install [Bitcoin Core](https://bitcoin.org/en/bitcoin-core/){:target="_blank"
 ## This may take some time
 
 Bitcoin Core will download the full Bitcoin blockchain, and validate all transactions since 2009.
-We're talking more than 800'000 blocks with a size of over 500 GB, so this is not an easy task.
+We're talking more than 900'000 blocks with a size of over 700 GB, so this is not an easy task.
 It's great that the Raspberry Pi 4 can do it, even if it takes a few days, as this was simply not possible with earlier models.
 
 ---
@@ -45,7 +45,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   # set up some version variables for easier maintenance later on
-  $ VERSION="29.1"
+  $ VERSION="30.0"
 
   # download Bitcoin Core binary
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
@@ -63,7 +63,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   $ sha256sum --ignore-missing --check SHA256SUMS
-  > bitcoin-29.1-aarch64-linux-gnu.tar.gz: OK
+  > bitcoin-30.0-aarch64-linux-gnu.tar.gz: OK
   ```
 
 ### Signature check
@@ -114,12 +114,12 @@ Expected output:
 ### Timestamp check
 
 * The binary checksum file is timestamped on the Bitcoin blockchain via the [OpenTimestamps protocol](https://opentimestamps.org/){:target="_blank"}, proving that the file existed prior to some point in time. Let's verify this timestamp. On your local computer, download the checksums file and its timestamp proof:
-  *  https://bitcoincore.org/bin/bitcoin-core-29.1/SHA256SUMS.ots
-  *  https://bitcoincore.org/bin/bitcoin-core-29.1/SHA256SUMS
+  *  https://bitcoincore.org/bin/bitcoin-core-30.0/SHA256SUMS.ots
+  *  https://bitcoincore.org/bin/bitcoin-core-30.0/SHA256SUMS
 * In your browser, open the [OpenTimestamps website](https://opentimestamps.org/){:target="_blank"}
 * In the "Stamp and verify" section, drop or upload the downloaded SHA256SUMS.ots proof file in the dotted box
 * In the next box, drop or upload the SHA256SUMS file
-* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v29.1){:target="_blank"} of Bitcoin Core v29.1.
+* If the timestamps is verified, you should see the following message. The timestamp proves that the checksums file existed on the [release date](https://github.com/bitcoin/bitcoin/releases/tag/v30.0){:target="_blank"} of Bitcoin Core v30.0.
 
 ![Bitcoin timestamp check](../../images/bitcoin-ots-check.PNG)
 
@@ -131,7 +131,7 @@ Expected output:
   $ tar -xvf bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
   $ sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-$VERSION/bin/*
   $ bitcoin-cli --version
-  > Bitcoin Core RPC client version v29.1.0
+  > Bitcoin Core RPC client version v30.0
   > Copyright (C) 2009-2025 The Bitcoin Core developers
   > [...]
   ```
@@ -260,6 +260,10 @@ We'll also set the proper access permissions.
   zmqpubrawblock=tcp://127.0.0.1:28332
   zmqpubrawtx=tcp://127.0.0.1:28333
   whitelist=download@127.0.0.1          # for Electrs
+
+  # Maximum size of data in OP_RETURN outputs we relay and mine. New default: 100_000 bytes
+  # old setting pre 30.0 below, adjust to your preference
+  datacarriersize=83
 
   # Raspberry Pi optimizations
   maxconnections=40
@@ -542,7 +546,7 @@ When upgrading, there might be breaking changes, or changes in the data structur
 
   ```sh
   # set up some version variables for easier maintenance later on
-  $ VERSION="29.1"
+  $ VERSION="30.0"
   # download Bitcoin Core binary, checksums, signature file, and timestamp file
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION-aarch64-linux-gnu.tar.gz
   $ wget https://bitcoincore.org/bin/bitcoin-core-$VERSION/SHA256SUMS
@@ -554,7 +558,7 @@ When upgrading, there might be breaking changes, or changes in the data structur
 
   ```sh
   $ sha256sum --ignore-missing --check SHA256SUMS
-  > bitcoin-29.1-aarch64-linux-gnu.tar.gz: OK
+  > bitcoin-30.0-aarch64-linux-gnu.tar.gz: OK
   ```
 
 * The next command download and imports automatically all signatures from the [Bitcoin Core release attestations (Guix)](https://github.com/bitcoin-core/guix.sigs) repository
@@ -598,11 +602,11 @@ Expected output:
 Expected output:
 
   ```sh
-  > Got 1 attestation(s) from https://btc.calendar.catallaxy.com
-  > Got 1 attestation(s) from https://finney.calendar.eternitywall.com
-  > Got 1 attestation(s) from https://bob.btc.calendar.opentimestamps.org
   > Got 1 attestation(s) from https://alice.btc.calendar.opentimestamps.org
-  > Success! Bitcoin block 892418 attests existence as of 2025-04-14 CEST
+  > Got 1 attestation(s) from https://bob.btc.calendar.opentimestamps.org
+  > Got 1 attestation(s) from https://finney.calendar.eternitywall.com
+  > Got 1 attestation(s) from https://btc.calendar.catallaxy.com
+  > Success! Bitcoin block 918612 attests existence as of 2025-10-11 CEST
   ```
 
 Now, just check that the timestamp date is close to the [release](https://github.com/bitcoin/bitcoin/releases) date of the version you're installing.
@@ -618,7 +622,7 @@ Now, just check that the timestamp date is close to the [release](https://github
 
   ```sh
   $ bitcoin-cli --version
-  > Bitcoin Core RPC client version v29.1.0
+  > Bitcoin Core RPC client version v30.0
   > Copyright (C) 2009-2025 The Bitcoin Core developers
   > [...]
   ```

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -262,7 +262,7 @@ We'll also set the proper access permissions.
   whitelist=download@127.0.0.1          # for Electrs
 
   # Maximum size of data in OP_RETURN outputs we relay and mine. New default: 100_000 bytes
-  # old setting pre 30.0 below, adjust to your preference
+  # note: new datacarriersize accounts for multiple OP_Returns to the limit specified here
   datacarriersize=83
 
   # Raspberry Pi optimizations

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -245,9 +245,6 @@ We'll also set the proper access permissions.
   server=1
   txindex=1
 
-  # Allow creation of legacy wallets (required for JoinMarket)
-  deprecatedrpc=create_bdb
-
   # Network
   listen=1
   listenonion=1


### PR DESCRIPTION
### What

Update Bitcoin Core client to latest version 30.0. 
Added: old default value of setting `datacarriersize` to `bitcoin.conf` to make users aware of it and adjust it to their preference.

#### Scope

- [x] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix
