### PR TITLE
Update bitcoin-client.md

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -432,7 +432,7 @@ After rebooting, "bitcoind" should start and begin to sync and validate the Bitc
   Exit with `Ctrl-C`
 
   ```sh
-  $ tail -f /data/bitcoin/debug.log
+  $ tail -f /home/admin/.bitcoin/debug.log
   ```
 
 * Use the Bitcoin Core client `bitcoin-cli` to get information about the current blockchain


### PR DESCRIPTION
As the link was created in a previous step, the correct path would be "tail -f /data/bitcoin/debug.log" instead of "tail -f /home/bitcoin/.bitcoin/debug.log", otherwise there could be a permission error