### PR TITLE
Correct cookie path in bitcoin-client.md

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -481,7 +481,7 @@ We also now want to enable the node to listen to and relay transactions.
   Save and exit.
 
   ```sh
-  $ nano /home/admin/.bitcoin/bitcoin.conf
+  $ sudo nano /home/admin/.bitcoin/bitcoin.conf
   ```
 
   ```


### PR DESCRIPTION
### What

Updated the path to the permission cookie. User `admin` has no permission to access `.cookie` file via path `/home/bitcoin/.bitcoin/.cookie`. `admin` should use `/home/admin/.bitcoin/.cookie`

### Why

New home permission settings on Debian 12

#### How

Verified on Debian 13

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes #1487

cc @martinatime 
