### PR TITLE
Update the netcat package for one used in Debian 12 - For Fulcrum install

### DIFF
--- a/guide/bonus/raspberry-pi/system-overview.md
+++ b/guide/bonus/raspberry-pi/system-overview.md
@@ -30,7 +30,7 @@ This script can be run by user "admin" without root privileges, but you should s
 * Install necessary software packages
 
   ```sh
-  $ sudo apt install jq net-tools netcat
+  $ sudo apt install jq net-tools netcat-openbsd
   ```
 
 * Download the script. 


### PR DESCRIPTION
Following the update to Debian 12 (or 13), netcat has no installation candidate for Debian 12, either netcat-openbsd or netcat-traditional should be used instead
