### PR TITLE
Remove pubkey of Adam Gibson from JoinMarket guide

### DIFF
--- a/guide/bonus/bitcoin/joinmarket.md
+++ b/guide/bonus/bitcoin/joinmarket.md
@@ -105,14 +105,6 @@ If this command fails with error `BDB wallet creation is deprecated and will be 
 * Get the PGP keys of JoinMarket developers that sign releases.
 
   ```sh
-  $ curl https://raw.githubusercontent.com/JoinMarket-Org/joinmarket-clientserver/master/pubkeys/AdamGibson.asc | gpg --import 
-  ```
-  ```
-  > ...
-  > gpg: key 141001A1AF77F20B: public key "Adam Gibson (CODE SIGNING KEY) <ekaggata@gmail.com>" imported
-  > ...
-  ```
-  ```sh
   $ curl https://raw.githubusercontent.com/JoinMarket-Org/joinmarket-clientserver/master/pubkeys/KristapsKaupe.asc | gpg --import
   ```
   ```


### PR DESCRIPTION
#### What

Remove import of gpg public key of Adam Gibson from JoinMarket guide.

### Why

Key is marked as lost, file is renamed and `gpg --import` command will fail. https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/b03c5effaeffece02eb89811ebb297eaa7afed68 (https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1772)

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [X] simple bug fix
