### PR TITLE
Create i2pd data directory on SSD, to reduce stress on SD card

### DIFF
--- a/guide/bonus/bitcoin/i2p.md
+++ b/guide/bonus/bitcoin/i2p.md
@@ -69,7 +69,7 @@ Table of contents
   ```sh
   $ sudo mkdir /data/i2pd
   $ sudo chown -R i2pd:i2pd /data/i2pd
-  $ mkdir -p /var/lib/i2pd
+  $ sudo mkdir -p /var/lib/i2pd
   $ sudo chown -R i2pd:i2pd /var/lib/i2pd
   $ mount --bind /data/i2pd /var/lib/i2pd
   $ echo "/data/i2pd /var/lib/i2pd none bind 0 0" | sudo tee -a /etc/fstab

--- a/guide/bonus/bitcoin/i2p.md
+++ b/guide/bonus/bitcoin/i2p.md
@@ -64,6 +64,19 @@ Table of contents
   $ sudo apt install i2pd
   ```
 
+* Create i2pd data directory on SSD, to reduce stress on SD card.
+
+  ```sh
+  $ sudo mkdir /data/i2pd
+  $ sudo chown -R i2pd:i2pd /data/i2pd
+  $ mkdir -p /var/lib/i2pd
+  $ sudo chown -R i2pd:i2pd /var/lib/i2pd
+  $ mount --bind /data/i2pd /var/lib/i2pd
+  $ echo "/data/i2pd /var/lib/i2pd none bind 0 0" | sudo tee -a /etc/fstab
+  /data/i2pd /var/lib/i2pd none bind 0 0
+  $ sudo sed -i 's|.*logfile =.*|logfile = /data/i2pd/i2pd.log|' /etc/i2pd/i2pd.conf
+  ```
+
 * Enable autoboot on startup
 
   ```sh

--- a/guide/bonus/bitcoin/i2p.md
+++ b/guide/bonus/bitcoin/i2p.md
@@ -64,7 +64,7 @@ Table of contents
   $ sudo apt install i2pd
   ```
 
-* Create i2pd data directory on SSD, to reduce stress on SD card.
+* Create i2pd data directory on SSD, to reduce stress on SD card
 
   ```sh
   $ sudo mkdir /data/i2pd


### PR DESCRIPTION
### Why

Reduce writes on SD card and also save up some space. It's recommended to have at least 20% free space on SD cards for optimal performance. I2pd data directory on my node was already above 500M.

Note that bind mount seems to be necessary as with symlinking `/var/lib/i2pd` to `/data/i2pd`, i2pd failed to start with error (perms were ok, owned by `i2pd:i2pd`):

```
Feb 19 15:42:15 odroid systemd[1]: Starting C++ daemon for accessing the I2P network...
Feb 19 15:42:15 odroid i2pd[232104]: terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
Feb 19 15:42:15 odroid i2pd[232104]:   what():  filesystem error: directory iterator cannot open directory: Permission denied [/var/lib/i2pd/tags]
Feb 19 15:42:15 odroid systemd[1]: i2pd.service: Control process exited, code=killed, status=6/ABRT
Feb 19 15:42:15 odroid systemd[1]: i2pd.service: Failed with result 'signal'.
Feb 19 15:42:15 odroid systemd[1]: Failed to start C++ daemon for accessing the I2P network.
```

#### Scope

- [ ] significant change to core configuration
- [X] independent bonus guide
- [ ] simple bug fix