### PR TITLE
fix: update Lychee fragment config

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -53,5 +53,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: lychee-report
-          path: lychee/out.md
+          path: out/lychee-report.md
           if-no-files-found: ignore

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -3,7 +3,7 @@
 # content stabilises by flipping offline = false.
 
 offline = true
-include_fragments = false
+include_fragments = "none"
 
 exclude = [
   # Next.js asset paths

--- a/guide/bonus/bitcoin/Jam.mdx
+++ b/guide/bonus/bitcoin/Jam.mdx
@@ -5,7 +5,7 @@ description: Web interface for JoinMarket focused on user-friendliness, with sen
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/Jam.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/Jam.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/UTXOracle.mdx
+++ b/guide/bonus/bitcoin/UTXOracle.mdx
@@ -5,7 +5,7 @@ description: Python script that estimates the BTC/USD price from your own blockc
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/UTXOracle.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/UTXOracle.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/bisq.mdx
+++ b/guide/bonus/bitcoin/bisq.mdx
@@ -5,7 +5,7 @@ description: Decentralized desktop exchange for privately buying and selling non
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/bisq.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/bisq.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/bitboxapp.mdx
+++ b/guide/bonus/bitcoin/bitboxapp.mdx
@@ -5,7 +5,7 @@ description: Beginner-friendly desktop wallet for the BitBox02 hardware wallet, 
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/bitboxapp.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/bitboxapp.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/electrum-personal-server.mdx
+++ b/guide/bonus/bitcoin/electrum-personal-server.mdx
@@ -5,7 +5,7 @@ description: Lightweight Electrum server that serves only your own wallets, as a
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/electrum-personal-server.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/electrum-personal-server.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/electrum-wallet-desktop.mdx
+++ b/guide/bonus/bitcoin/electrum-wallet-desktop.mdx
@@ -5,7 +5,7 @@ description: Feature-rich desktop Bitcoin wallet for power users, connected to y
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/electrum-wallet-desktop.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/electrum-wallet-desktop.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/fulcrum.mdx
+++ b/guide/bonus/bitcoin/fulcrum.mdx
@@ -5,7 +5,7 @@ description: Fast and nimble Electrum-compatible SPV server, a performance-focus
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/fulcrum.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/fulcrum.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/i2p.mdx
+++ b/guide/bonus/bitcoin/i2p.mdx
@@ -5,7 +5,7 @@ description: Anonymous network layer you can run alongside Tor to give Bitcoin C
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/i2p.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/i2p.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/joinmarket.mdx
+++ b/guide/bonus/bitcoin/joinmarket.mdx
@@ -5,7 +5,7 @@ description: Decentralized marketplace for CoinJoin transactions to improve on-c
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/joinmarket.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/joinmarket.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/sparrow-terminal.mdx
+++ b/guide/bonus/bitcoin/sparrow-terminal.mdx
@@ -5,7 +5,7 @@ description: Headless version of Sparrow Wallet intended for systems without a d
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/sparrow-terminal.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/sparrow-terminal.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/specter-desktop.mdx
+++ b/guide/bonus/bitcoin/specter-desktop.mdx
@@ -5,7 +5,7 @@ description: User-friendly GUI around Bitcoin Core with a focus on multisig usin
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/specter-desktop.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/specter-desktop.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/testnet.mdx
+++ b/guide/bonus/bitcoin/testnet.mdx
@@ -5,7 +5,7 @@ description: Configure your RaspiBolt to run on Bitcoin testnet so you can exper
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/testnet.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/testnet.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/bitcoin/white-paper.mdx
+++ b/guide/bonus/bitcoin/white-paper.mdx
@@ -5,7 +5,7 @@ description: Reconstruct the Bitcoin white paper PDF directly from the blockchai
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/bitcoin/white-paper.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/bitcoin/white-paper.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/ambossping.mdx
+++ b/guide/bonus/lightning/ambossping.mdx
@@ -5,7 +5,7 @@ description: Shell script that sends health-check heartbeats from your node to t
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/ambossping.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/ambossping.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/balance-of-satoshis.mdx
+++ b/guide/bonus/lightning/balance-of-satoshis.mdx
@@ -5,7 +5,7 @@ description: LND power-user toolkit for rebalancing channels, monitoring the nod
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/balance-of-satoshis.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/balance-of-satoshis.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/charge-lnd.mdx
+++ b/guide/bonus/lightning/charge-lnd.mdx
@@ -5,7 +5,7 @@ description: Policy-based fee manager for LND that sets per-channel fee rates fr
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/charge-lnd.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/charge-lnd.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/circuit-breaker.mdx
+++ b/guide/bonus/lightning/circuit-breaker.mdx
@@ -5,7 +5,7 @@ description: Lightning firewall that protects LND from HTLC-flooding griefing at
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/circuit-breaker.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/circuit-breaker.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/clboss.mdx
+++ b/guide/bonus/lightning/clboss.mdx
@@ -5,7 +5,7 @@ description: Automated channel and liquidity manager for Core Lightning that ope
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/clboss.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/clboss.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/cln.mdx
+++ b/guide/bonus/lightning/cln.mdx
@@ -5,7 +5,7 @@ description: Alternative Lightning implementation you can run instead of LND, or
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/cln.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/cln.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/lightning-terminal.mdx
+++ b/guide/bonus/lightning/lightning-terminal.mdx
@@ -5,7 +5,7 @@ description: Browser-based UI from Lightning Labs for managing LND channel liqui
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/lightning-terminal.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/lightning-terminal.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/lnbalance.mdx
+++ b/guide/bonus/lightning/lnbalance.mdx
@@ -5,7 +5,7 @@ description: Simple shell script that prints a quick balance overview for your L
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/lnbalance.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/lnbalance.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/lnbits.mdx
+++ b/guide/bonus/lightning/lnbits.mdx
@@ -5,7 +5,7 @@ description: Free and open-source Lightning wallet and accounts system with a pl
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/lnbits.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/lnbits.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/lnchannels.mdx
+++ b/guide/bonus/lightning/lnchannels.mdx
@@ -5,7 +5,7 @@ description: Simple shell script that prints a summary of all channels on your L
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/lnchannels.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/lnchannels.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/lndg.mdx
+++ b/guide/bonus/lightning/lndg.mdx
@@ -5,7 +5,7 @@ description: Lightweight web GUI for power users to monitor and automate LND rou
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/lndg.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/lndg.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/lntop.mdx
+++ b/guide/bonus/lightning/lntop.mdx
@@ -5,7 +5,7 @@ description: Interactive text-mode channel viewer for Lightning nodes, inspired 
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/lntop.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/lntop.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/rebalance-lnd.mdx
+++ b/guide/bonus/lightning/rebalance-lnd.mdx
@@ -5,7 +5,7 @@ description: Command-line tool for circular rebalancing of LND channels to even 
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/rebalance-lnd.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/rebalance-lnd.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/regolancer.mdx
+++ b/guide/bonus/lightning/regolancer.mdx
@@ -5,7 +5,7 @@ description: Lightweight LND rebalancer written in Go, focused on fast and effic
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/regolancer.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/regolancer.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/remote-lncli.mdx
+++ b/guide/bonus/lightning/remote-lncli.mdx
@@ -5,7 +5,7 @@ description: Run lncli from a separate computer on your network to control your 
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/remote-lncli.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/remote-lncli.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/thunderhub.mdx
+++ b/guide/bonus/lightning/thunderhub.mdx
@@ -5,7 +5,7 @@ description: Open-source browser dashboard for managing and monitoring an LND no
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/thunderhub.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/thunderhub.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/zap-desktop.mdx
+++ b/guide/bonus/lightning/zap-desktop.mdx
@@ -5,7 +5,7 @@ description: Cross-platform Lightning Network wallet with a focus on user experi
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/zap-desktop.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/zap-desktop.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/lightning/zap-ios.mdx
+++ b/guide/bonus/lightning/zap-ios.mdx
@@ -5,7 +5,7 @@ description: iOS Lightning wallet that connects to your RaspiBolt over the local
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/lightning/zap-ios.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/lightning/zap-ios.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/aliases.mdx
+++ b/guide/bonus/raspberry-pi/aliases.mdx
@@ -5,7 +5,7 @@ description: Set up shell aliases for common node-management commands to cut typ
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/aliases.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/aliases.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/boot-from-microsd-card.mdx
+++ b/guide/bonus/raspberry-pi/boot-from-microsd-card.mdx
@@ -5,7 +5,7 @@ description: Boot the Raspberry Pi from microSD while using the external drive f
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/boot-from-microsd-card.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/boot-from-microsd-card.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/command-line.mdx
+++ b/guide/bonus/raspberry-pi/command-line.mdx
@@ -5,7 +5,7 @@ description: Customize your shell prompt with colors and a Bitcoin symbol, and m
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/command-line.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/command-line.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/go.mdx
+++ b/guide/bonus/raspberry-pi/go.mdx
@@ -5,7 +5,7 @@ description: Install, update, or uninstall the Go toolchain, which several bonus
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/go.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/go.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/homer.mdx
+++ b/guide/bonus/raspberry-pi/homer.mdx
@@ -5,7 +5,7 @@ description: Browser-based dashboard with quick links to every web service runni
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/homer.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/homer.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/odroid-setup.mdx
+++ b/guide/bonus/raspberry-pi/odroid-setup.mdx
@@ -5,7 +5,7 @@ description: Run the RaspiBolt stack on an Odroid XU4 or compatible board as an 
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/odroid-setup.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/odroid-setup.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/system-overview.mdx
+++ b/guide/bonus/raspberry-pi/system-overview.mdx
@@ -5,7 +5,7 @@ description: Greet yourself on SSH login with a one-screen status dashboard of B
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/system-overview.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/system-overview.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/trezor-agent.mdx
+++ b/guide/bonus/raspberry-pi/trezor-agent.mdx
@@ -5,7 +5,7 @@ description: Use a Trezor hardware wallet as a second factor for SSH authenticat
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/trezor-agent.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/trezor-agent.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/upgrade-external-drive.mdx
+++ b/guide/bonus/raspberry-pi/upgrade-external-drive.mdx
@@ -5,7 +5,7 @@ description: Migrate from a smaller to a larger external drive as the blockchain
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/upgrade-external-drive.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/upgrade-external-drive.md)
 while we port it over.
 </Callout>
 

--- a/guide/bonus/raspberry-pi/ups-nut.mdx
+++ b/guide/bonus/raspberry-pi/ups-nut.mdx
@@ -5,7 +5,7 @@ description: Configure Network UPS Tools so your node shuts down cleanly when a 
 
 <Callout type="info" title="Migration in progress">
 This bonus page hasn't been rewritten for RaspiBolt v4 yet. The v3
-version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/master/guide/bonus/raspberry-pi/ups-nut.md)
+version still works, see the [original guide on GitHub](https://github.com/raspibolt/raspibolt/blob/v3-final/guide/bonus/raspberry-pi/ups-nut.md)
 while we port it over.
 </Callout>
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -43,6 +43,6 @@ exclude = [
 cache = true
 max_cache_age = "7d"
 
-# Output: write a markdown report alongside CLI output.
+# Output: write a markdown report inside the generated site directory.
 format = "markdown"
-output = "./lychee/out.md"
+output = "./out/lychee-report.md"


### PR DESCRIPTION
Fixes the production Pages deploy with Lychee v0.24: `include_fragments` now uses the required `"none"` mode instead of the removed boolean syntax.\n\nValidated with `npm test`, `npm run build`, and Lychee v0.24.2 against the generated `out/` tree (0 errors).