### PR TITLE
docs: refresh v4 publication details

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,6 @@
 # NEXT_PUBLIC_SITE_URL=https://raspibolt.org
 
 # Path prefix the site is served from. Required when the deploy host
-# is not the domain root (e.g. GitHub Pages serves stadicus.github.io/RaspiBolt).
+# is not the domain root (for example, a preview under /docs).
 # Empty string for a root deploy. Set in CI via the publish workflow.
-# NEXT_PUBLIC_BASE_PATH=/RaspiBolt
+# NEXT_PUBLIC_BASE_PATH=/docs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 5
-    target-branch: 'feature/v4-rewrite'
+    target-branch: 'master'
     groups:
       next-ecosystem:
         patterns:
@@ -41,5 +41,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    target-branch: 'feature/v4-rewrite'
+    target-branch: 'master'
     open-pull-requests-limit: 3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 RaspiBolt is a self-custody Bitcoin and Lightning full-node guide for technically capable hobbyists. People who can follow terminal commands but may not be Bitcoin experts. The guide walks through a complete setup on a Raspberry Pi, from flashing the OS to running Lightning payments.
 
-**v4 goal:** Rewrite the guide on Next.js + Fumadocs (MDX). Modernize structure, update all software versions, and establish a sustainable, automatable publishing workflow. The feature branch `feature/v4-rewrite` auto-deploys to the staging preview at https://stadicus.github.io/RaspiBolt/. The reasoning behind the stack (including why Quarto was tried and dropped) is captured in [`DECISIONS.md`](./DECISIONS.md).
+**Current state:** RaspiBolt v4 runs on Next.js + Fumadocs (MDX) at https://raspibolt.org. The feature branch `feature/v4-rewrite` auto-deploys to the staging preview at https://next.raspibolt.org. The v3 guide is archived at https://v3.raspibolt.org. The reasoning behind the stack (including why Quarto was tried and dropped) is captured in [`DECISIONS.md`](./DECISIONS.md).
 
 ---
 
@@ -24,7 +24,7 @@ No approval needed. Act and commit.
 
 1. Write, migrate, or rewrite any content section
 2. Make prose decisions: structure, wording, what to cut from v3, what to rewrite
-3. Commit and push to `feature/v4-rewrite`
+3. Commit and push to the branch for the change
 4. Update software versions in `lib/versions.json`
 5. Fix lint/spell/markdownlint failures
 6. Update `testing/test-runner.sh` tests to match migrated content
@@ -53,8 +53,8 @@ Present a recommendation and wait for approval.
 
 Only on explicit instruction.
 
-1. Merge `feature/v4-rewrite` into `master`
-2. Open a PR toward the upstream `raspibolt/RaspiBolt` repository
+1. Merge a pull request into `master`
+2. Change the production deployment workflow or its repository guard
 3. Change the `CNAME` or published domain configuration
 4. Force-push to any branch
 
@@ -199,7 +199,7 @@ Images live in `public/images/` at the repo root. Reference them with root-relat
 ![Raspberry Pi 5 board](/images/raspberry-pi-5.png)
 ```
 
-This keeps images discoverable for contributors (one place to look) and plays nicely with the `/RaspiBolt/` basePath on the staging deploy; Next.js rewrites root-relative paths automatically.
+This keeps images discoverable for contributors in one place. Next.js rewrites root-relative paths automatically when a base path is configured.
 
 Optimize PNG/JPG to <300 KB before committing (use `oxipng -o 4 file.png` or an equivalent). Screenshots of the Raspberry Pi Imager UI tend to go stale fast, so prefer numbered steps with bold UI labels over screenshots.
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -13,7 +13,8 @@ Dates from `git log --all --date=short`. Most of this document captures decision
 - **2017** — v1 written as a Medium post (see [`backstory.mdx`](./guide/backstory.mdx)).
 - **2018-03-15** — repo's first commit (`8c3a906`). Guide runs on **Jekyll** + GitHub Pages for the next several years. `raspibolt.org` becomes canonical.
 - **2026-04-21** — v4 kicks off. First commits (`34955b6`, `4beceb8`) start a **Quarto** scaffold. Same day, side-by-side prototypes of Next.js + Fumadocs and hand-crafted HTML (`3f9b8fc`) lead to the pivot to Next.js + Fumadocs (`3204c6c`). Quarto attempt never shipped.
-- **2026-04**: v3 content migrated section by section (hardware, Bitcoin, Lightning, bonus stubs). Landing page, styleguide, CI workflows, and Docker-based testing harness built in parallel. `feature/v4-rewrite` in active development; staging auto-deploys to `stadicus.github.io/RaspiBolt`, `raspibolt.org` continues to serve v3.
+- **2026-04**: v3 content migrated section by section (hardware, Bitcoin, Lightning, bonus stubs). Landing page, styleguide, CI workflows, and Docker-based testing harness built in parallel. At that time, `feature/v4-rewrite` deployed to `stadicus.github.io/RaspiBolt` while `raspibolt.org` continued to serve v3.
+- **2026-08-18**: v4 merged into `master` and deployed to `https://raspibolt.org`. `https://next.raspibolt.org` remains the noindexed staging deployment from `feature/v4-rewrite`; `https://v3.raspibolt.org` is the noindexed v3 archive at tag `v3-final`.
 
 ---
 
@@ -185,16 +186,17 @@ Not in CI (needs a privileged container). Has caught real guide bugs: missing `x
 
 ## Deployment
 
-| Environment | URL                                     | Source branch                          |
-| ----------- | --------------------------------------- | -------------------------------------- |
-| Staging     | `https://stadicus.github.io/RaspiBolt/` | `feature/v4-rewrite`                   |
-| Production  | `https://raspibolt.org`                 | `master` (v3 today, v4 after cut-over) |
+| Environment | URL                          | Source branch        |
+| ----------- | ---------------------------- | -------------------- |
+| Staging     | `https://next.raspibolt.org` | `feature/v4-rewrite` |
+| Production  | `https://raspibolt.org`      | `master`             |
+| Archive     | `https://v3.raspibolt.org`   | `v3-final`           |
 
-Staging is noindexed. `site-publish.yml` force-pushes `out/` to `gh-pages`.
+Staging is noindexed. Both staging and production deploy through GitHub Pages Actions; the archive remains a separate, noindexed v3 site.
 
 ### basePath
 
-Staging serves at `/RaspiBolt/`, production at `/`. `next.config.mjs` reads `NEXT_PUBLIC_BASE_PATH`:
+Both current deployments serve at the domain root. `next.config.mjs` still supports an optional `NEXT_PUBLIC_BASE_PATH` for an alternate preview:
 
 ```js
 basePath: process.env.NEXT_PUBLIC_BASE_PATH ?? '',

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Edit [`lib/versions.json`](./lib/versions.json) to update; every page re-renders
 | Bitcoin Core | 31.1 |
 | LND | 0.21.2-beta |
 | Electrs | 0.11.1 |
-| RTL | 0.15.10 |
+| RTL | 0.15.11 |
 | Mempool | 3.3.1 |
 | Node.js | 24 LTS |
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Build your own self-sovereign Bitcoin and Lightning node on a Raspberry Pi.
 
 - **Published guide:** <https://raspibolt.org>
-- **v4 staging preview:** <https://stadicus.github.io/RaspiBolt/> *(auto-deploys from `feature/v4-rewrite`)*
+- **v4 staging preview:** <https://next.raspibolt.org> *(auto-deploys from `feature/v4-rewrite`)*
+- **v3 archive:** <https://v3.raspibolt.org> *(read-only, noindex)*
 - **Project history and decisions:** [`DECISIONS.md`](./DECISIONS.md): why the stack, content, and tooling choices are what they are
 - **Open decisions & deferred work:** [`TODO.md`](./TODO.md)
 
@@ -32,6 +33,7 @@ guide/
 - **Callouts** use Fumadocs' `<Callout type="info|warn|success|error">...</Callout>`.
 - **Internal links** use bare paths: `/docs/raspberry-pi/preparations`, no file extension.
 - **Code blocks** always specify a language (`bash`, `text`, `ini`, etc.) and hold **one shell command each**, so the copy button hands the reader exactly one paste-ready command. Heredocs, pipelines, and reference lists stay together; see `CLAUDE.md` for the exceptions.
+- **Homepage freshness:** when a reader-facing guide change is published, update the `v4 · Updated Month YYYY` badge in [`src/app/(home)/page.tsx`](./src/app/(home)/page.tsx).
 
 See [`CLAUDE.md`](./CLAUDE.md) for the full voice and syntax guidelines.
 
@@ -49,8 +51,8 @@ See [`CLAUDE.md`](./CLAUDE.md) for the full voice and syntax guidelines.
 ### First-time setup
 
 ```bash
-git clone https://github.com/Stadicus/RaspiBolt.git
-cd RaspiBolt
+git clone https://github.com/raspibolt/raspibolt.git
+cd raspibolt
 bash scripts/setup-dev.sh
 ```
 
@@ -122,7 +124,7 @@ Vale rules are in [`.vale/styles/RaspiBolt/`](./.vale/styles/RaspiBolt); accepte
 - **Framework:** [Next.js 16](https://nextjs.org) with static export
 - **Docs theme:** [Fumadocs](https://fumadocs.dev)
 - **Styling:** Tailwind CSS 4
-- **Deployment:** GitHub Pages (via [`.github/workflows/site-publish.yml`](./.github/workflows/site-publish.yml))
+- **Deployment:** GitHub Pages, production via [`.github/workflows/site-publish-prod.yml`](./.github/workflows/site-publish-prod.yml) and staging via [`.github/workflows/site-publish.yml`](./.github/workflows/site-publish.yml)
 - **Variable resolution:** Custom [remark plugin](./lib/remark-variables.ts)
 
 ```
@@ -138,7 +140,7 @@ testing/
   REPORT.md           Latest walk report (per-page PASS/FAIL)
 ```
 
-### Software versions (v4 target)
+### Current software versions
 
 Edit [`lib/versions.json`](./lib/versions.json) to update; every page re-renders on next build.
 
@@ -153,4 +155,4 @@ Edit [`lib/versions.json`](./lib/versions.json) to update; every page re-renders
 
 ---
 
-*v4 rewrite in progress on `feature/v4-rewrite`. Current stable guide: <https://raspibolt.org>*
+*RaspiBolt v4 is the current guide at <https://raspibolt.org>. RaspiBolt v3 remains available at <https://v3.raspibolt.org>.*

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# RaspiBolt v4: open decisions and deferred work
+# RaspiBolt: open decisions and deferred work
 
 Tracking file for non-urgent items: open design decisions, deferred content work, tooling nice-to-haves. One place to look when a session starts, without touching `CLAUDE.md` (which is in the prompt cache; every edit invalidates it).
 
@@ -12,20 +12,18 @@ Add new items at the top of the relevant section. Strike items by moving them to
 
 ---
 
-## Pre-cutover checklist
+## Launch status
 
-Items to clear before merging v4 to upstream `raspibolt/raspibolt` master:
-
-- **Tag `v3-final`** on the last v3 commit of upstream master, push, then merge v4. Archive plan posted upstream: [raspibolt/raspibolt#1527](https://github.com/raspibolt/raspibolt/issues/1527) (open, awaiting community feedback on whether a rendered v3 site must stay online and where the pointer goes). Resolve that thread before tagging.
-- **Add "Looking for v3?" pointer** in v4 footer linking to `https://github.com/raspibolt/raspibolt/tree/v3-final`.
-- **Test Tailscale install flow on a Pi 5 Trixie** (see Deferred content below).
+- RaspiBolt v4 is live at <https://raspibolt.org>.
+- The noindexed v3 archive is live at <https://v3.raspibolt.org> from tag `v3-final`.
+- The noindexed staging deployment remains at <https://next.raspibolt.org> from `feature/v4-rewrite`.
 
 ---
 
 ## Deferred content
 
 - **Bonus sections** (`guide/bonus/**`) are stubs with v3 source links. Full content migration deferred until the main path is battle-tested.
-- **Test Tailscale install flow on a Pi 5 Trixie**. The privacy.mdx Tailscale steps are written from upstream docs but haven't been walked on real hardware. Verify before v4 goes live.
+- **Test Tailscale install flow on a Pi 5 Trixie**. The privacy.mdx Tailscale steps are written from upstream docs but haven't been walked on real hardware.
 
 ---
 

--- a/guide/bitcoin/desktop-wallet.mdx
+++ b/guide/bitcoin/desktop-wallet.mdx
@@ -60,7 +60,7 @@ A quick piece of framing before you install anything.
 
 Sparrow is happiest when it's watch-only plus a hardware wallet on
 a USB port. This is why, if you can swing it, you'll want a
-BitBox02, Coldcard, Jade, Ledger, or Trezor before you load real
+BitBox02, Jade, Ledger, or Trezor before you load real
 funds into this setup.
 
 ## Install Sparrow
@@ -146,8 +146,8 @@ world. A quick tour:
   transaction, and let your hardware wallet sign it. Sparrow shows
   the exact bytes the device will sign, every fee, and every
   change output. Nothing is hidden.
-- **PSBT:** if the signing device lives air-gapped (a Coldcard with
-  an SD card, for example), export a Partially Signed Bitcoin
+- **PSBT:** if the signing device lives air-gapped and uses removable
+  storage, export a Partially Signed Bitcoin
   Transaction, sign on the cold device, and import the signed PSBT
   back. Same result; no USB.
 

--- a/lib/versions.json
+++ b/lib/versions.json
@@ -2,7 +2,7 @@
   "bitcoin_core": "31.1",
   "lnd": "0.21.2-beta",
   "electrs": "0.11.1",
-  "rtl": "0.15.10",
+  "rtl": "0.15.11",
   "mempool": "3.3.1",
   "nodejs": "24"
 }

--- a/lychee.toml
+++ b/lychee.toml
@@ -30,6 +30,10 @@ exclude = [
   # Example placeholders in the guide
   "\\.onion",
   "raspibolt\\.local",
+  # PR builds use the staging domain for canonical metadata. The static
+  # output is checked locally via --root-dir; do not make CI depend on the
+  # availability of the separate staging deployment.
+  "https?://next\\.raspibolt\\.org",
   # Git SSH schema (not HTTP)
   "^git@",
   "^ssh://",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,9 +2,8 @@ import { createMDX } from 'fumadocs-mdx/next';
 
 const withMDX = createMDX();
 
-// GitHub Pages deploy lives at https://stadicus.github.io/RaspiBolt/,
-// so assets and internal links need the /RaspiBolt prefix.
-// Skipped in local dev (NEXT_PUBLIC_BASE_PATH not set).
+// Both current deployments serve from their domain root. Keep this optional
+// base path for alternate previews served below a path prefix.
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
 /** @type {import('next').NextConfig} */

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -36,7 +36,7 @@ export default function HomePage() {
 
         <div className="mx-auto max-w-6xl px-6 py-24 md:py-32">
           <div className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-xs font-semibold tracking-widest text-amber-700 uppercase dark:text-amber-300">
-            v4 &middot; June 2026
+            v4 &middot; Updated August 2026
           </div>
           <h1 className="text-fd-foreground mt-4 text-5xl font-bold tracking-tight md:text-7xl">
             Build your own{' '}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { appDescription, appName, appTagline, isProductionSite, siteUrl } from '
 import './global.css';
 
 // Umami analytics. Separate websites for production (raspibolt.org)
-// and staging (stadicus.github.io/RaspiBolt) so traffic doesn't mix.
+// and staging (next.raspibolt.org) so traffic doesn't mix.
 // isProductionSite is resolved at build time from NEXT_PUBLIC_SITE_URL.
 // The script only renders in production builds; data-domains is a
 // second guard so a locally served production build can't pollute
@@ -14,7 +14,7 @@ import './global.css';
 const umamiWebsiteId = isProductionSite
   ? 'f6788a01-2c1f-429f-815b-73d15af26a27'
   : '3a6df4e2-9a81-4678-b782-88b940e22045';
-const umamiDomains = isProductionSite ? 'raspibolt.org' : 'stadicus.github.io';
+const umamiDomains = isProductionSite ? 'raspibolt.org' : 'next.raspibolt.org';
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
@@ -53,7 +53,7 @@ export const metadata: Metadata = {
     creator: '@stadicus',
   },
   // Only the canonical production domain (raspibolt.org) should be
-  // indexed. Staging (stadicus.github.io/RaspiBolt) and PR previews
+  // indexed. Staging (next.raspibolt.org) and PR previews
   // get full noindex so they don't compete with prod in search.
   robots: isProductionSite
     ? { index: true, follow: true }

--- a/src/components/screenshot.tsx
+++ b/src/components/screenshot.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 // Next.js only rewrites <Link> and <Image> for basePath; plain <img>
-// needs the prefix applied manually so staging (/RaspiBolt) resolves.
+// needs the prefix applied manually when an alternate preview uses one.
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
 export function Screenshot({ src, alt, caption, stale, float }: Props) {

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -27,9 +27,8 @@ export default function DefaultSearchDialog(props: SharedProps) {
   const { search, setSearch, query } = useDocsSearch({
     type: 'static',
     // Fumadocs' static-search client defaults to '/api/search', which ignores
-    // Next.js' basePath. Under /RaspiBolt/ the browser would fetch the bare
-    // origin and 404. Prepend NEXT_PUBLIC_BASE_PATH so the URL lands on the
-    // emitted out/api/search file.
+    // Next.js' optional basePath. Prepend NEXT_PUBLIC_BASE_PATH so an
+    // alternate path-prefixed preview resolves the emitted out/api/search file.
     from: `${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/api/search`,
     initOrama,
     locale,

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -7,9 +7,9 @@ export const docsImageRoute = '/og/docs';
 export const docsContentRoute = '/llms.mdx/docs';
 
 // Canonical site URL for Open Graph, Twitter cards, sitemap, and
-// canonical links. Defaults to the GitHub Pages staging target;
+// canonical links. Defaults to the staging target;
 // override via NEXT_PUBLIC_SITE_URL when cutting over to raspibolt.org.
-export const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://stadicus.github.io/RaspiBolt';
+export const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://next.raspibolt.org';
 
 // True when we're building for the canonical production domain.
 // Everything else (staging, PR previews, local dev) is treated as


### PR DESCRIPTION
## What changed

- update the homepage freshness badge and document the update rule
- refresh guide wording for hardware-wallet and PSBT usage
- replace stale v4 cutover, staging, and archive references
- update RTL to 0.15.11
- target future Dependabot updates at the production branch

## Validation

- `npm test`
- `npm run types:check`
- `npm run lint` (five existing `<img>` warnings only)
- `npm run build`
- Lychee internal link check (0 errors)
- `git diff --check`