### PR TITLE
fix: refresh v4 social preview image

### DIFF
--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { appName, appTagline } from '@/lib/shared';
+import { appName } from '@/lib/shared';
 
 // Root-level OG image. Shown on Twitter / Mastodon / LinkedIn / iMessage
 // link previews when no page-specific OG image is set (landing, 404,
@@ -10,7 +10,7 @@ import { appName, appTagline } from '@/lib/shared';
 
 export const dynamic = 'force-static';
 
-export const alt = `${appName} - ${appTagline}`;
+export const alt = `${appName} v4 - Build your own do-everything-yourself Bitcoin node`;
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -24,48 +24,113 @@ export default async function Image() {
         width: '100%',
         height: '100%',
         display: 'flex',
-        alignItems: 'center',
-        padding: '80px',
-        background: 'linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%)',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '54px 64px 48px',
+        color: '#1c140d',
+        backgroundColor: '#fffbeb',
+        backgroundImage:
+          'linear-gradient(rgba(245, 158, 11, 0.11) 1px, transparent 1px), linear-gradient(90deg, rgba(245, 158, 11, 0.11) 1px, transparent 1px), radial-gradient(circle at 88% 18%, rgba(249, 115, 22, 0.18), transparent 32%)',
+        backgroundSize: '64px 64px, 64px 64px, 100% 100%',
       }}
     >
-      <img
-        src={logoSrc}
-        width={200}
-        height={200}
-        style={{ borderRadius: 44, border: '1px solid rgba(120, 53, 15, 0.15)' }}
-        alt=""
-      />
-
       <div
         style={{
           display: 'flex',
-          flexDirection: 'column',
-          marginLeft: 64,
-          color: '#78350f',
+          width: '100%',
+          alignItems: 'center',
+          justifyContent: 'space-between',
         }}
       >
         <div
           style={{
-            fontSize: 128,
+            display: 'flex',
+            alignItems: 'center',
+            fontSize: 34,
             fontWeight: 800,
-            letterSpacing: -4,
+            letterSpacing: -1.5,
             lineHeight: 1,
           }}
         >
-          {appName}
+          <img
+            src={logoSrc}
+            width={72}
+            height={72}
+            style={{
+              marginRight: 20,
+              border: '1px solid rgba(120, 53, 15, 0.14)',
+              borderRadius: 18,
+            }}
+            alt=""
+          />
+          <span>{appName}</span>
         </div>
         <div
           style={{
-            fontSize: 32,
-            marginTop: 20,
+            display: 'flex',
+            padding: '10px 18px',
+            border: '1px solid rgba(245, 158, 11, 0.52)',
+            borderRadius: 999,
+            background: 'rgba(245, 158, 11, 0.12)',
             color: '#92400e',
-            lineHeight: 1.3,
-            maxWidth: 560,
+            fontSize: 19,
+            fontWeight: 700,
+            letterSpacing: 2,
           }}
         >
-          {appTagline}
+          VERSION 4
         </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', marginTop: 4 }}>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 74,
+            fontWeight: 800,
+            letterSpacing: -4.2,
+            lineHeight: 1.02,
+          }}
+        >
+          Build your own
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            color: '#f97316',
+            fontSize: 74,
+            fontWeight: 800,
+            letterSpacing: -4.2,
+            lineHeight: 1.02,
+          }}
+        >
+          do-everything-yourself
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 74,
+            fontWeight: 800,
+            letterSpacing: -4.2,
+            lineHeight: 1.02,
+          }}
+        >
+          Bitcoin node.
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          width: '100%',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          color: '#78350f',
+          fontSize: 22,
+        }}
+      >
+        <span>Bitcoin · Lightning · Self-custody</span>
+        <span style={{ fontWeight: 700 }}>raspibolt.org</span>
       </div>
     </div>,
     { ...size },

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -97,7 +97,7 @@ export default async function Image() {
         <div
           style={{
             display: 'flex',
-            color: '#f97316',
+            color: '#d65f0b',
             fontSize: 74,
             fontWeight: 800,
             letterSpacing: -4.2,


### PR DESCRIPTION
## What changed

- replace the generic root Open Graph card with a v4-branded 1200×630 image
- match the current landing page with the warm grid, orange accent, v4 badge, and current headline
- update the image alt text to identify RaspiBolt v4

## Why

The homepage still rendered the previous generic social preview. Social platforms therefore showed an outdated card when sharing `raspibolt.org`, despite the v4 guide already being live.

Next.js fingerprints the generated image, so this change also produces a new Open Graph and Twitter image URL to invalidate platform caches after deployment.

## Validation

- `npm run types:check`
- `npm run lint` (existing `no-img-element` warnings only)
- `NEXT_PUBLIC_SITE_URL=https://raspibolt.org npm run build`
- inspected the rendered `out/opengraph-image` at 1200×630
- confirmed `og:image` and `twitter:image` use the same new hash URL and updated alt text
