### PR TITLE
fix: serve valid social preview metadata

### DIFF
--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -31,7 +31,7 @@ const exportDir = resolve(process.cwd(), 'out');
 const rootHtmlPath = resolve(exportDir, 'index.html');
 const socialImagePath = resolve(exportDir, 'opengraph-image');
 const socialImagePngPath = resolve(exportDir, 'opengraph-image.png');
-const socialImagePattern = /opengraph-image\?[^"'<>\s]+/g;
+const socialImagePattern = /opengraph-image\?[a-zA-Z0-9]+/g;
 const rootHtml = readFileSync(rootHtmlPath, 'utf8');
 const rewrittenRootHtml = rootHtml.replace(socialImagePattern, 'opengraph-image.png');
 

--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
@@ -22,3 +22,23 @@ const html = `<!DOCTYPE html>
 
 writeFileSync(resolve(outDir, 'index.html'), html, 'utf8');
 console.log(`wrote out/docs/index.html -> ${target}`);
+
+// Next emits the generated root social image without a file extension. GitHub
+// Pages consequently serves it as application/octet-stream, which social-card
+// crawlers reject. Publish an explicit PNG path and rewrite the generated root
+// metadata to use it.
+const exportDir = resolve(process.cwd(), 'out');
+const rootHtmlPath = resolve(exportDir, 'index.html');
+const socialImagePath = resolve(exportDir, 'opengraph-image');
+const socialImagePngPath = resolve(exportDir, 'opengraph-image.png');
+const socialImagePattern = /opengraph-image\?[^"'<>\s]+/g;
+const rootHtml = readFileSync(rootHtmlPath, 'utf8');
+const rewrittenRootHtml = rootHtml.replace(socialImagePattern, 'opengraph-image.png');
+
+if (rewrittenRootHtml === rootHtml) {
+  throw new Error('Could not find the generated root social-image URL in out/index.html');
+}
+
+copyFileSync(socialImagePath, socialImagePngPath);
+writeFileSync(rootHtmlPath, rewrittenRootHtml, 'utf8');
+console.log('wrote out/opengraph-image.png and updated root social metadata');

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -1,7 +1,7 @@
 export const appName = 'RaspiBolt';
-export const appTagline = 'Self-custody Bitcoin & Lightning on a Raspberry Pi';
+export const appTagline = 'Sovereign Bitcoin & Lightning node';
 export const appDescription =
-  'A step-by-step guide to building your own sovereign Bitcoin and Lightning node on a Raspberry Pi. No custodian, no cloud, just you and the protocol.';
+  'Build your own sovereign Bitcoin and Lightning node on a Raspberry Pi—step by step, with no custodian or cloud.';
 export const docsRoute = '/docs';
 export const docsImageRoute = '/og/docs';
 export const docsContentRoute = '/llms.mdx/docs';


### PR DESCRIPTION
## What changed

- publish the generated root social card at an explicit `.png` URL
- rewrite the exported root metadata to reference that PNG
- shorten the root title and description for social and search previews

## Why

GitHub Pages served Next.js' extensionless `opengraph-image` export as
`application/octet-stream`. Social-card validators therefore rejected the URL
even though its contents were a valid 1200×630 PNG.

## Validation

- `npm run format:check`
- `npm run lint` (five existing `no-img-element` warnings)
- `NEXT_PUBLIC_SITE_URL=https://raspibolt.org npm run build`
- verified generated title length: 46 characters
- verified generated description length: 111 characters
- verified `out/opengraph-image.png` is a 1200×630 PNG
- verified root Open Graph and X metadata reference `https://raspibolt.org/opengraph-image.png`
