### PR TITLE
chore: limit Dependabot to security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,45 +1,24 @@
 version: 2
 
 updates:
-  # npm deps — group patch/minor updates into a single weekly PR.
+  # npm — disable routine version PRs and group security fixes.
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
       day: 'monday'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     target-branch: 'master'
     groups:
-      next-ecosystem:
+      security-updates:
+        applies-to: 'security-updates'
         patterns:
-          - 'next'
-          - 'eslint-config-next'
-          - '@types/react*'
-          - 'react'
-          - 'react-dom'
-      fumadocs:
-        patterns:
-          - 'fumadocs-*'
-          - '@orama/*'
-      dev-tooling:
-        patterns:
-          - 'eslint'
-          - 'eslint-*'
-          - '@typescript-eslint/*'
-          - 'prettier'
-          - 'prettier-*'
-          - 'vitest'
-          - 'typescript'
-          - '@types/*'
-      minor-and-patch:
-        update-types:
-          - 'minor'
-          - 'patch'
+          - '*'
 
-  # GitHub Actions — keep action versions current.
+  # GitHub Actions — disable routine version PRs.
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
     target-branch: 'master'
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## What changed

- disable routine npm version-update pull requests
- disable routine GitHub Actions version-update pull requests
- keep npm security updates enabled and group them into one pull request

## Why

Weekly version bumps created substantial PR and CI noise. Security alerts and
automatic security updates remain enabled in the repository settings, while
this configuration limits Dependabot PRs to actionable security fixes.

## Validation

- parsed `.github/dependabot.yml` as YAML
- repository `yamllint` and Prettier hooks passed
- configuration follows GitHub's documented `open-pull-requests-limit: 0` and
  `applies-to: security-updates` options
