### PR TITLE
fix(bonus): warn about archived c-lightning-REST in the CLN stub

### DIFF
--- a/.vale/styles/config/vocabularies/RaspiBolt/accept.txt
+++ b/.vale/styles/config/vocabularies/RaspiBolt/accept.txt
@@ -47,6 +47,7 @@ rescanning
 
 # Lightning
 CLN
+clnrest
 Eclair
 [Ww]atchtower(s)?
 [Pp]athfinding

--- a/guide/bonus/lightning/cln.mdx
+++ b/guide/bonus/lightning/cln.mdx
@@ -9,6 +9,26 @@ version still works, see the [original guide on GitHub](https://github.com/raspi
 while we port it over.
 </Callout>
 
+<Callout type="warn" title="Skip the c-lightning-REST section in the v3 guide">
+The "c-lightning-Rest & RTL" chapter of the linked v3 guide is out of
+date and no longer leads anywhere useful.
+
+[c-lightning-REST](https://github.com/Ride-The-Lightning/c-lightning-REST)
+was archived on 24 July 2026. It receives no further updates, including
+no security fixes. RTL dropped support for it in v0.15.0 and moved to
+CLN's built-in [`clnrest`](https://docs.corelightning.org/docs/rest) with
+rune authentication, and RaspiBolt pins RTL v%versions.rtl%. Following the
+v3 steps therefore leaves you with a plugin your RTL version cannot talk
+to.
+
+Everything else in the v3 guide, installing and running CLN itself, is
+still valid. For node management, set `clnrest-port` in your CLN config,
+mint a rune with `lightning-cli createrune`, and point RTL at clnrest
+instead of the plugin. The rewritten instructions land here when this
+page is ported. Details and progress:
+[raspibolt/raspibolt#1532](https://github.com/raspibolt/raspibolt/issues/1532).
+</Callout>
+
 [Core Lightning](https://github.com/ElementsProject/lightning) (CLN)
 is a lightweight, highly customizable implementation of the
 Lightning Network protocol from Blockstream. You can run it as a


### PR DESCRIPTION
#### What

Adds a warning callout to the Core Lightning bonus stub, telling readers to skip the "c-lightning-Rest & RTL" chapter of the v3 guide it links to.

### Why

The stub currently sends readers to the v3 guide with no caveat, and that guide's REST/RTL chapter walks them into a setup that cannot work:

- [c-lightning-REST](https://github.com/Ride-The-Lightning/c-lightning-REST) was archived on 24 July 2026. No further updates, **including no security fixes**.
- RTL dropped support for it in v0.15.0 and moved to CLN's built-in `clnrest` with rune authentication. `lib/versions.json` pins RTL `0.15.11`, so a reader following the v3 steps ends up with a plugin their pinned RTL cannot talk to.

Reported by @saubyk in #1532, with the background from the c-lightning-REST side.

#### How

- `<Callout type="warn">` in `guide/bonus/lightning/cln.mdx` naming exactly what to skip, what replaces it (`clnrest-port`, `lightning-cli createrune`, RTL `runePath`), and linking #1532 for progress.
- The rest of the v3 guide, installing and running CLN itself, is explicitly still marked valid.
- `clnrest` added to the Vale vocabulary.

This is deliberately the small fix. The full clnrest rewrite is the port of this page and wants a hardware review before it ships; this stops the bleeding in the meantime.

#### Scope

- [ ] significant change to core configuration
- [x] independent bonus guide
- [ ] simple bug fix

Refs #1532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ykGx7WuyQ14k9FB3eJVfu